### PR TITLE
Fix: "failed to seek" issue when going back in the queue

### DIFF
--- a/qobuz-player-controls/src/player.rs
+++ b/qobuz-player-controls/src/player.rs
@@ -277,7 +277,11 @@ impl Player {
             && new_position < current_position as i32
             && self.position.borrow().as_millis() > 1000
         {
-            self.seek(Duration::default())?;
+            self.position.send(Default::default())?;
+
+            if tracklist.skip_to_track(current_position as i32).is_some() {
+                self.new_queue(tracklist).await?;
+            }
             return Ok(());
         }
 

--- a/qobuz-player-tui/src/queue.rs
+++ b/qobuz-player-tui/src/queue.rs
@@ -121,7 +121,7 @@ impl QueueState {
                         let index = self.state.selected();
 
                         if let Some(index) = index {
-                            controls.skip_to_position(index, false);
+                            controls.skip_to_position(index, true);
                         }
                         Output::Consumed
                     }


### PR DESCRIPTION
Current: when pressing "p" or "enter" on a previous track in the queue, it fails with "Failed to seek" error.

I have modified the previous track logic to reload and restart the current track from scratch instead of trying to seek within the existing stream. This achieves the same result (restarting the song) but bypasses the faulty seek operation.

This should ensure that pressing "p" or "previous" consistently restarts the track without error, regardless of how long it has been playing.