### PR TITLE
TUI fixes for cover display & run async

### DIFF
--- a/qobuz-player-controls/src/tracklist.rs
+++ b/qobuz-player-controls/src/tracklist.rs
@@ -186,23 +186,23 @@ impl Tracklist {
 
     pub fn entity_playing(&self) -> Entity {
         let current_track = self.current_track();
-        let cover_link = current_track.as_ref().and_then(|track| track.image.clone());
+        let track_image = current_track.as_ref().and_then(|track| track.image.clone());
 
         match self.list_type() {
             TracklistType::Album(tracklist) => Entity {
                 title: Some(tracklist.title.clone()),
                 link: Some(format!("/album/{}", tracklist.id)),
-                cover_link,
+                cover_link: tracklist.image.clone().or(track_image),
             },
             TracklistType::Playlist(tracklist) => Entity {
                 title: Some(tracklist.title.clone()),
                 link: Some(format!("/playlist/{}", tracklist.id)),
-                cover_link,
+                cover_link: tracklist.image.clone().or(track_image),
             },
             TracklistType::TopTracks(tracklist) => Entity {
                 title: Some(tracklist.artist_name.clone()),
                 link: Some(format!("/artist/{}", tracklist.id)),
-                cover_link,
+                cover_link: tracklist.image.clone().or(track_image),
             },
             TracklistType::Tracks => Entity {
                 title: current_track
@@ -211,7 +211,7 @@ impl Tracklist {
                 link: current_track
                     .as_ref()
                     .and_then(|track| track.album_id.as_ref().map(|id| format!("/album/{id}"))),
-                cover_link,
+                cover_link: track_image,
             },
         }
     }

--- a/qobuz-player-tui/src/app.rs
+++ b/qobuz-player-tui/src/app.rs
@@ -68,6 +68,7 @@ pub struct App {
     pub notifications: NotificationList,
     pub full_screen: bool,
     pub disable_tui_album_cover: bool,
+    pub current_image_url: Option<String>,
 }
 
 #[derive(Default)]
@@ -163,6 +164,8 @@ impl App {
         let mut tick_interval = time::interval(Duration::from_millis(100));
         let mut receiver = self.broadcast.subscribe();
         let mut event_stream = EventStream::new();
+        let (image_tx, mut image_rx) =
+            tokio::sync::mpsc::channel::<Option<(StatefulProtocol, f32)>>(1);
 
         while !self.exit {
             tokio::select! {
@@ -184,9 +187,29 @@ impl App {
                     let tracklist = self.tracklist.borrow_and_update().clone();
                     self.queue.set_items(tracklist.queue().into_iter().cloned().collect());
                     let status = self.now_playing.status;
-                    self.now_playing = get_current_state(tracklist, status).await;
+                    let (mut new_state, image_url) = get_current_state_without_image(&tracklist, status);
+
+                    if image_url == self.current_image_url {
+                        new_state.image = self.now_playing.image.take();
+                    } else if !self.disable_tui_album_cover {
+                        if let Some(url) = image_url.clone() {
+                            let tx = image_tx.clone();
+                            tokio::spawn(async move {
+                                let result = fetch_image(&url).await;
+                                let _ = tx.send(result).await;
+                            });
+                        }
+                        self.current_image_url = image_url;
+                    }
+
+                    self.now_playing = new_state;
                     self.should_draw = true;
                 },
+
+                Some(image) = image_rx.recv() => {
+                    self.now_playing.image = image;
+                    self.should_draw = true;
+                }
 
                 Ok(_) = self.status.changed() => {
                     let status = self.status.borrow_and_update();
@@ -509,32 +532,33 @@ async fn fetch_image(image_url: &str) -> Option<(StatefulProtocol, f32)> {
     let response = client.get(image_url).send().await.ok()?;
     let img_bytes = response.bytes().await.ok()?;
 
-    let image = load_from_memory(&img_bytes).ok()?;
-    let ratio = image.width() as f32 / image.height() as f32;
-
-    let picker = Picker::from_query_stdio().ok()?;
-    Some((picker.new_resize_protocol(image), ratio))
+    tokio::task::spawn_blocking(move || {
+        let image = load_from_memory(&img_bytes).ok()?;
+        let ratio = image.width() as f32 / image.height() as f32;
+        let picker = Picker::from_query_stdio().ok()?;
+        Some((picker.new_resize_protocol(image), ratio))
+    })
+    .await
+    .ok()?
 }
 
-pub async fn get_current_state(tracklist: Tracklist, status: Status) -> NowPlayingState {
+pub fn get_current_state_without_image(
+    tracklist: &Tracklist,
+    status: Status,
+) -> (NowPlayingState, Option<String>) {
     let entity = tracklist.entity_playing();
     let track = tracklist.current_track().cloned();
-    let image = if let Some(image_url) = entity.cover_link {
-        Some(fetch_image(&image_url).await)
-    } else {
-        None
-    }
-    .flatten();
+    let image_url = entity.cover_link.clone();
 
-    let tracklist_length = tracklist.total();
-
-    NowPlayingState {
-        image,
+    let state = NowPlayingState {
+        image: None,
         entity_title: entity.title,
         playing_track: track,
-        tracklist_length,
+        tracklist_length: tracklist.total(),
         status,
         tracklist_position: tracklist.current_position(),
         duration_ms: 0,
-    }
+    };
+
+    (state, image_url)
 }

--- a/qobuz-player-tui/src/lib.rs
+++ b/qobuz-player-tui/src/lib.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use app::{App, get_current_state};
+use app::{App, get_current_state_without_image};
 use favorites::FavoritesState;
 use qobuz_player_controls::{
     AppResult, ExitSender, PositionReceiver, StatusReceiver, TracklistReceiver, client::Client,
@@ -40,7 +40,8 @@ pub async fn init(
     let tracklist_value = tracklist_receiver.borrow().clone();
     let status_value = *status_receiver.borrow();
     let queue = tracklist_value.queue().into_iter().cloned().collect();
-    let now_playing = get_current_state(tracklist_value, status_value).await;
+    let (now_playing, current_image_url) =
+        get_current_state_without_image(&tracklist_value, status_value);
 
     let mut app = App {
         broadcast,
@@ -56,6 +57,7 @@ pub async fn init(
         should_draw: true,
         app_state: Default::default(),
         disable_tui_album_cover,
+        current_image_url,
         favorites: FavoritesState::new(&client).await?,
         search: Default::default(),
         queue: QueueState::new(queue),


### PR DESCRIPTION
Hello hello,

This PR aims to fix two issues I had with the TUI:
- freezes on track changes
- low res cover images

Changes:
- entity_playing() now uses the album/playlist-level image (higher resolution) with fallback to the track thumbnail. Previously it always used current_track.image.
- load_from_memory + new_resize_protocol so that they don't block the player
- skips image refetch entirely when the url hasn't changed (same album, next track)
- image gets downloaded in the background