### PR TITLE
feat(gtk): unify library content background with header tone

### DIFF
--- a/qobuz-player-gtk/src/lib.rs
+++ b/qobuz-player-gtk/src/lib.rs
@@ -1,6 +1,7 @@
 use std::{cell::RefCell, rc::Rc, sync::Arc, time::Duration};
 
 use adw::{Application, prelude::*};
+use gtk4::{gdk, CssProvider};
 use libadwaita::{self as adw, ApplicationWindow};
 use qobuz_player_controls::{
     AppResult, ExitSender, PositionReceiver, Status, StatusReceiver, TracklistReceiver,
@@ -69,6 +70,29 @@ fn extract_code_from_uri(uri: &str) -> Option<String> {
         .map(|(_, v)| v.to_string())
 }
 
+fn load_app_css() {
+    let provider = CssProvider::new();
+    provider.load_from_string(
+        r#"
+.app-content,
+.app-content stack,
+.app-content overlay,
+.app-content scrolledwindow,
+.app-content viewport,
+.app-content gridview {
+    background-color: @headerbar_bg_color;
+    background-image: none;
+}
+"#,
+    );
+
+    gtk4::style_context_add_provider_for_display(
+        &gdk::Display::default().expect("No display found"),
+        &provider,
+        gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
+    );
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn init(
     client: Arc<Client>,
@@ -81,6 +105,7 @@ pub fn init(
     exit_sender: ExitSender,
 ) -> AppResult<()> {
     libadwaita::init().unwrap();
+    load_app_css();
 
     let application = libadwaita::Application::builder()
         .application_id("io.github.sofusa.qobine")

--- a/qobuz-player-gtk/src/ui/app_shell.rs
+++ b/qobuz-player-gtk/src/ui/app_shell.rs
@@ -47,6 +47,7 @@ impl AppShell {
             .vexpand(true)
             .hexpand(true)
             .build();
+        stack.add_css_class("app-content");
         stack.add_named(albums_page.borrow().widget(), Some("albums"));
         stack.add_named(artists_page.borrow().widget(), Some("artists"));
         stack.add_named(playlists_page.borrow().widget(), Some("playlists"));
@@ -191,9 +192,11 @@ impl AppShell {
         sidebar_toolbar.set_content(Some(&sidebar));
 
         let content_toolbar = adw::ToolbarView::new();
+        content_toolbar.add_css_class("app-content");
         content_toolbar.add_top_bar(&content_header);
 
         let content_overlay = gtk4::Overlay::builder().vexpand(true).hexpand(true).build();
+        content_overlay.add_css_class("app-content");
 
         content_overlay.set_child(Some(&stack));
         content_overlay.add_overlay(&spinner_box);


### PR DESCRIPTION
Apply scoped app-content CSS so Albums, Artists and Playlists content uses the same dark surface as the top header for visual consistency.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2262eed9-530b-497b-868a-b434e5117f01" />
