### PR TITLE
Polish GTK mini-player layout and controls

### DIFF
--- a/qobuz-player-gtk/src/lib.rs
+++ b/qobuz-player-gtk/src/lib.rs
@@ -118,6 +118,11 @@ fn load_app_css() {
     margin: 0;
     min-height: 0;
 }
+
+.now-playing-main-play {
+    min-width: 40px;
+    min-height: 40px;
+}
 "#,
     );
 

--- a/qobuz-player-gtk/src/lib.rs
+++ b/qobuz-player-gtk/src/lib.rs
@@ -112,6 +112,12 @@ fn load_app_css() {
 .now-playing-progress-active:hover highlight {
     min-height: 10px;
 }
+
+.now-playing-subtitle-link {
+    padding: 0;
+    margin: 0;
+    min-height: 0;
+}
 "#,
     );
 

--- a/qobuz-player-gtk/src/lib.rs
+++ b/qobuz-player-gtk/src/lib.rs
@@ -69,6 +69,58 @@ fn extract_code_from_uri(uri: &str) -> Option<String> {
         .map(|(_, v)| v.to_string())
 }
 
+fn load_app_css() {
+    let provider = CssProvider::new();
+    provider.load_from_string(
+        r#"
+.app-content,
+.app-content stack,
+.app-content overlay,
+.app-content scrolledwindow,
+.app-content viewport,
+.app-content gridview {
+    background-color: @headerbar_bg_color;
+    background-image: none;
+}
+
+.now-playing-bar {
+    border-radius: 0;
+}
+
+.now-playing-progress {
+    padding: 0;
+    margin: 0;
+    background: transparent;
+    background-image: none;
+}
+
+.now-playing-progress trough,
+.now-playing-progress highlight {
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+    min-height: 1px;
+    transition: min-height 100ms ease;
+}
+
+.now-playing-progress-active trough,
+.now-playing-progress-active highlight {
+    min-height: 5px;
+}
+
+.now-playing-progress-active:hover trough,
+.now-playing-progress-active:hover highlight {
+    min-height: 10px;
+}
+"#,
+    );
+
+    gtk4::style_context_add_provider_for_display(
+        &gdk::Display::default().expect("No display found"),
+        &provider,
+        gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
+    );
+}
 #[allow(clippy::too_many_arguments)]
 pub fn init(
     client: Arc<Client>,
@@ -81,6 +133,7 @@ pub fn init(
     exit_sender: ExitSender,
 ) -> AppResult<()> {
     libadwaita::init().unwrap();
+    load_app_css();
 
     let application = libadwaita::Application::builder()
         .application_id("io.github.sofusa.qobine")

--- a/qobuz-player-gtk/src/ui/now_playing_bar.rs
+++ b/qobuz-player-gtk/src/ui/now_playing_bar.rs
@@ -36,7 +36,8 @@ impl NowPlayingBar {
         on_open_playlist: Rc<dyn Fn(PlaylistHeaderInfo)>,
     ) -> Self {
         let title_label = gtk4::Label::builder()
-            .halign(gtk4::Align::Center)
+            .halign(gtk4::Align::Start)
+            .xalign(0.0)
             .ellipsize(gtk4::pango::EllipsizeMode::End)
             .wrap(false)
             .build();
@@ -44,16 +45,17 @@ impl NowPlayingBar {
 
         let subtitle_box = gtk4::Box::builder()
             .orientation(gtk4::Orientation::Horizontal)
-            .halign(gtk4::Align::Center)
+            .halign(gtk4::Align::Start)
             .build();
 
-        let text_box = gtk4::Box::builder()
+        let info_box = gtk4::Box::builder()
             .orientation(gtk4::Orientation::Vertical)
-            .halign(gtk4::Align::Center)
+            .halign(gtk4::Align::Start)
+            .valign(gtk4::Align::Center)
             .hexpand(true)
             .build();
-        text_box.append(&title_label);
-        text_box.append(&subtitle_box);
+        info_box.append(&title_label);
+        info_box.append(&subtitle_box);
 
         let controls_box = gtk4::Box::builder()
             .orientation(gtk4::Orientation::Horizontal)
@@ -147,8 +149,7 @@ impl NowPlayingBar {
             .valign(gtk4::Align::Center)
             .build();
 
-        left_box.append(&text_box);
-        left_box.append(&controls_box);
+        left_box.append(&info_box);
         let cover = gtk4::Image::builder()
             .pixel_size(96)
             .halign(gtk4::Align::Center)
@@ -159,17 +160,42 @@ impl NowPlayingBar {
         cover_frame.set_size_request(96, 96);
         cover_frame.set_valign(gtk4::Align::Center);
 
-        let content = gtk4::Box::builder()
+        let now_playing_info = gtk4::Box::builder()
             .orientation(gtk4::Orientation::Horizontal)
-            .spacing(16)
+            .spacing(12)
+            .halign(gtk4::Align::Start)
+            .valign(gtk4::Align::Center)
+            .hexpand(true)
+            .build();
+        now_playing_info.append(&cover_frame);
+        now_playing_info.append(&left_box);
+
+        let center_controls = gtk4::Box::builder()
+            .orientation(gtk4::Orientation::Horizontal)
+            .halign(gtk4::Align::Center)
+            .valign(gtk4::Align::Center)
+            .hexpand(true)
+            .build();
+        center_controls.append(&controls_box);
+
+        let right_spacer = gtk4::Box::builder()
+            .orientation(gtk4::Orientation::Horizontal)
+            .halign(gtk4::Align::End)
+            .hexpand(true)
+            .build();
+
+        let content = gtk4::Grid::builder()
+            .column_homogeneous(true)
+            .column_spacing(12)
             .margin_start(16)
             .margin_end(16)
             .margin_top(12)
             .margin_bottom(12)
             .build();
 
-        content.append(&cover_frame);
-        content.append(&left_box);
+        content.attach(&now_playing_info, 0, 0, 1, 1);
+        content.attach(&center_controls, 1, 0, 1, 1);
+        content.attach(&right_spacer, 2, 0, 1, 1);
 
         let frame_content = gtk4::Box::builder()
             .orientation(gtk4::Orientation::Vertical)
@@ -224,6 +250,8 @@ pub fn update_now_playing(bar: &NowPlayingBar, tracklist: &Tracklist) {
     let make_label = |text: &str| {
         let l = gtk4::Label::builder()
             .label(text)
+            .xalign(0.0)
+            .halign(gtk4::Align::Start)
             .ellipsize(gtk4::pango::EllipsizeMode::End)
             .build();
         l.add_css_class("dim-label");
@@ -232,6 +260,8 @@ pub fn update_now_playing(bar: &NowPlayingBar, tracklist: &Tracklist) {
 
     let append_sep = || {
         let sep = make_label("·");
+        sep.set_margin_start(4);
+        sep.set_margin_end(4);
         bar.subtitle_box.append(&sep);
     };
 
@@ -256,6 +286,7 @@ pub fn update_now_playing(bar: &NowPlayingBar, tracklist: &Tracklist) {
             let button = clickable_tile(&label.upcast(), move || {
                 on_open(AlbumHeaderInfo { id: id.clone() })
             });
+            button.add_css_class("now-playing-subtitle-link");
             bar.subtitle_box.append(&button);
 
             if let (Some(name), Some(artist_id)) = (&track.artist_name, track.artist_id) {
@@ -266,6 +297,7 @@ pub fn update_now_playing(bar: &NowPlayingBar, tracklist: &Tracklist) {
                 let button = clickable_tile(&label.upcast(), move || {
                     on_open(ArtistHeaderInfo { id: artist_id })
                 });
+                button.add_css_class("now-playing-subtitle-link");
                 bar.subtitle_box.append(&button);
             }
         }
@@ -278,6 +310,7 @@ pub fn update_now_playing(bar: &NowPlayingBar, tracklist: &Tracklist) {
             let button = clickable_tile(&label.upcast(), move || {
                 on_open(PlaylistHeaderInfo { id });
             });
+            button.add_css_class("now-playing-subtitle-link");
             bar.subtitle_box.append(&button);
 
             if let (Some(name), Some(artist_id)) = (&track.artist_name, track.artist_id) {
@@ -288,6 +321,7 @@ pub fn update_now_playing(bar: &NowPlayingBar, tracklist: &Tracklist) {
                 let button = clickable_tile(&label.upcast(), move || {
                     on_open(ArtistHeaderInfo { id: artist_id });
                 });
+                button.add_css_class("now-playing-subtitle-link");
                 bar.subtitle_box.append(&button);
             }
         }
@@ -299,6 +333,7 @@ pub fn update_now_playing(bar: &NowPlayingBar, tracklist: &Tracklist) {
             let button = clickable_tile(&label.upcast(), move || {
                 on_open(ArtistHeaderInfo { id });
             });
+            button.add_css_class("now-playing-subtitle-link");
             bar.subtitle_box.append(&button);
         }
 
@@ -310,6 +345,7 @@ pub fn update_now_playing(bar: &NowPlayingBar, tracklist: &Tracklist) {
                 let button = clickable_tile(&label.upcast(), move || {
                     on_open(AlbumHeaderInfo { id: id.clone() });
                 });
+                button.add_css_class("now-playing-subtitle-link");
                 bar.subtitle_box.append(&button);
             }
 
@@ -320,6 +356,7 @@ pub fn update_now_playing(bar: &NowPlayingBar, tracklist: &Tracklist) {
                 let button = clickable_tile(&label.upcast(), move || {
                     on_open(ArtistHeaderInfo { id: artist_id });
                 });
+                button.add_css_class("now-playing-subtitle-link");
                 bar.subtitle_box.append(&button);
             }
         }

--- a/qobuz-player-gtk/src/ui/now_playing_bar.rs
+++ b/qobuz-player-gtk/src/ui/now_playing_bar.rs
@@ -152,13 +152,13 @@ impl NowPlayingBar {
 
         left_box.append(&info_box);
         let cover = gtk4::Image::builder()
-            .pixel_size(96)
+            .pixel_size(84)
             .halign(gtk4::Align::Center)
             .valign(gtk4::Align::Center)
             .build();
         let cover_frame = gtk4::Frame::builder().child(&cover).build();
         cover_frame.add_css_class("card");
-        cover_frame.set_size_request(96, 96);
+        cover_frame.set_size_request(84, 84);
         cover_frame.set_valign(gtk4::Align::Center);
 
         let now_playing_info = gtk4::Box::builder()
@@ -190,8 +190,8 @@ impl NowPlayingBar {
             .column_spacing(12)
             .margin_start(16)
             .margin_end(16)
-            .margin_top(12)
-            .margin_bottom(12)
+            .margin_top(10)
+            .margin_bottom(10)
             .build();
 
         content.attach(&now_playing_info, 0, 0, 1, 1);

--- a/qobuz-player-gtk/src/ui/now_playing_bar.rs
+++ b/qobuz-player-gtk/src/ui/now_playing_bar.rs
@@ -91,12 +91,14 @@ impl NowPlayingBar {
             .width_chars(6)
             .xalign(0.0)
             .build();
+        progress_current_label.add_css_class("dim-label");
 
         let progress_total_label = gtk4::Label::builder()
             .label("0:00")
             .width_chars(6)
             .xalign(1.0)
             .build();
+        progress_total_label.add_css_class("dim-label");
 
         let progress_scale = gtk4::Scale::builder()
             .orientation(gtk4::Orientation::Horizontal)
@@ -104,6 +106,9 @@ impl NowPlayingBar {
             .draw_value(false)
             .focusable(false)
             .build();
+        progress_scale.set_valign(gtk4::Align::Start);
+        progress_scale.add_css_class("now-playing-progress");
+        progress_scale.add_css_class("now-playing-progress-active");
 
         let controls_seek = controls.clone();
         progress_scale.connect_change_value(move |_, _, value| {
@@ -114,11 +119,27 @@ impl NowPlayingBar {
         let progress_box = gtk4::Box::builder()
             .orientation(gtk4::Orientation::Horizontal)
             .hexpand(true)
+            .margin_top(0)
+            .margin_bottom(0)
+            .margin_start(0)
+            .margin_end(0)
             .build();
 
-        progress_box.append(&progress_current_label);
+        let progress_time_box = gtk4::Box::builder()
+            .orientation(gtk4::Orientation::Horizontal)
+            .hexpand(true)
+            .spacing(8)
+            .margin_top(10)
+            .margin_start(8)
+            .margin_end(8)
+            .build();
+
+        let progress_spacer = gtk4::Box::builder().hexpand(true).build();
+
         progress_box.append(&progress_scale);
-        progress_box.append(&progress_total_label);
+        progress_time_box.append(&progress_current_label);
+        progress_time_box.append(&progress_spacer);
+        progress_time_box.append(&progress_total_label);
 
         let left_box = gtk4::Box::builder()
             .orientation(gtk4::Orientation::Vertical)
@@ -128,30 +149,54 @@ impl NowPlayingBar {
 
         left_box.append(&text_box);
         left_box.append(&controls_box);
-        left_box.append(&progress_box);
-
-        let cover = gtk4::Image::builder().pixel_size(130).build();
+        let cover = gtk4::Image::builder()
+            .pixel_size(96)
+            .halign(gtk4::Align::Center)
+            .valign(gtk4::Align::Center)
+            .build();
         let cover_frame = gtk4::Frame::builder().child(&cover).build();
         cover_frame.add_css_class("card");
+        cover_frame.set_size_request(96, 96);
+        cover_frame.set_valign(gtk4::Align::Center);
 
         let content = gtk4::Box::builder()
             .orientation(gtk4::Orientation::Horizontal)
-            .spacing(24)
-            .margin_start(24)
-            .margin_end(24)
-            .margin_top(24)
-            .margin_bottom(24)
+            .spacing(16)
+            .margin_start(16)
+            .margin_end(16)
+            .margin_top(12)
+            .margin_bottom(12)
             .build();
 
         content.append(&cover_frame);
         content.append(&left_box);
 
-        let frame = gtk4::Frame::builder().child(&content).build();
+        let frame_content = gtk4::Box::builder()
+            .orientation(gtk4::Orientation::Vertical)
+            .spacing(0)
+            .build();
+        frame_content.append(&progress_time_box);
+        frame_content.append(&content);
+
+        let frame = gtk4::Frame::builder().child(&frame_content).build();
         frame.add_css_class("card");
+        frame.add_css_class("now-playing-bar");
+        frame.set_margin_top(1);
+
+        let overlay = gtk4::Overlay::new();
+        overlay.set_child(Some(&frame));
+        progress_box.set_valign(gtk4::Align::Start);
+        overlay.add_overlay(&progress_box);
+
+        let root = gtk4::Box::builder()
+            .orientation(gtk4::Orientation::Vertical)
+            .spacing(0)
+            .build();
+        root.append(&overlay);
 
         let revealer = gtk4::Revealer::builder()
             .transition_type(gtk4::RevealerTransitionType::SlideUp)
-            .child(&frame)
+            .child(&root)
             .reveal_child(false)
             .build();
 

--- a/qobuz-player-gtk/src/ui/now_playing_bar.rs
+++ b/qobuz-player-gtk/src/ui/now_playing_bar.rs
@@ -63,7 +63,7 @@ impl NowPlayingBar {
 
         let controls_prev = controls.clone();
         let prev_button = gtk4::Button::builder()
-            .icon_name("media-seek-backward-symbolic")
+            .icon_name("media-skip-backward-symbolic")
             .build();
         prev_button.add_css_class("flat");
         prev_button.connect_clicked(move |_| controls_prev.previous());
@@ -77,7 +77,7 @@ impl NowPlayingBar {
 
         let controls_next = controls.clone();
         let next_button = gtk4::Button::builder()
-            .icon_name("media-seek-forward-symbolic")
+            .icon_name("media-skip-forward-symbolic")
             .build();
         next_button.add_css_class("flat");
         next_button.connect_clicked(move |_| controls_next.next());

--- a/qobuz-player-gtk/src/ui/now_playing_bar.rs
+++ b/qobuz-player-gtk/src/ui/now_playing_bar.rs
@@ -74,7 +74,8 @@ impl NowPlayingBar {
         let play_button = gtk4::Button::builder()
             .icon_name("media-playback-start-symbolic")
             .build();
-        play_button.add_css_class("flat");
+        play_button.add_css_class("circular");
+        play_button.add_css_class("now-playing-main-play");
         play_button.connect_clicked(move |_| controls_play_pause.play_pause());
 
         let controls_next = controls.clone();


### PR DESCRIPTION
- Redesign progress section with overlay seek bar
- Center transport controls, align metadata left
- Refine play/pause button (circular, 40×40)
- Update skip button icons to symbolic variants
- Reduce mini-player height

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ea911fbd-b133-4838-8661-4ee81057b2c4" />
