### PR TITLE
Update installation instructions and fix typo for qobuz-player-tui

### DIFF
--- a/qobuz-player-tui/README.md
+++ b/qobuz-player-tui/README.md
@@ -12,12 +12,12 @@ Download the tar.gz file for your supported OS from the releases page, extract t
 ### Installation with cargo
 Terminal app:
 ```
-cargo install --git https://github.com/SofusA/qobuz-player --bin qobuz-player-tui
+cargo install --git https://github.com/SofusA/qobine qobuz-player-tui
 ```
 
 Web server app:
 ```
-cargo install --git https://github.com/SofusA/qobuz-player --bin qobuz-player-web
+cargo install --git https://github.com/SofusA/qobine qobuz-player-web
 ```
 
 ### Installation from the aur (unofficial)

--- a/qobuz-player-tui/README.md
+++ b/qobuz-player-tui/README.md
@@ -12,7 +12,7 @@ Download the tar.gz file for your supported OS from the releases page, extract t
 ### Installation with cargo
 Terminal app:
 ```
-cargo install --git https://github.com/SofusA/qobuz-player --bin qobuz-player
+cargo install --git https://github.com/SofusA/qobuz-player --bin qobuz-player-tui
 ```
 
 Web server app:


### PR DESCRIPTION
Minor update to change reference from "qobuz-player" to "qobine"

Also I removed the "--bin" argument as I was getting the following error. With "--bin" removed it seemed to install just fine.

```
$ cargo install --git https://github.com/SofusA/qobine --bin qobuz-player-tui
    Updating git repository `https://github.com/SofusA/qobine`
error: multiple packages with binaries found: qobuz-player-connect, qobuz-player-gtk, qobuz-player-rfid, qobuz-player-tui, qobuz-player-web. When installing a git repository, cargo will always search the entire repo for any Cargo.toml.
Please specify a package, e.g. `cargo install --git https://github.com/SofusA/qobine qobuz-player-connect`.
```