### PR TITLE
Feat legacy streaming

### DIFF
--- a/qobuz-player-cli/src/lib.rs
+++ b/qobuz-player-cli/src/lib.rs
@@ -23,6 +23,11 @@ pub struct SharedArgs {
     /// Use provided device for audio output, instead of default.
     /// Use qobuz-player list-devices for output device list
     pub output_device_id: Option<String>,
+
+    /// Use the legacy track endpoint instead of CMAF streaming
+    /// because of cpus like pi4 on which crypto ops are not accelerated
+    #[clap(long, default_value_t = false)]
+    pub legacy_streaming: bool,
 }
 
 #[derive(Args, Debug)]
@@ -96,7 +101,7 @@ pub async fn handle_shared_commands(
     match command {
         SharedCommands::Login => {
             let (_client, oauth_result) =
-                Client::new_with_oauth_login(AudioQuality::Mp3, headless).await?;
+                Client::new_with_oauth_login(AudioQuality::Mp3, false, headless).await?;
 
             database.set_credentials(oauth_result.into()).await?;
             println!("Login successful! You can now run qobuz-player.");
@@ -119,15 +124,16 @@ pub async fn handle_shared_commands(
 pub async fn get_client(
     database: &Database,
     max_audio_quality: AudioQuality,
+    legacy_streaming: bool,
     headless: bool,
 ) -> AppResult<Client> {
     let database_credentials = database.get_credentials().await?;
 
     let client = match database_credentials {
-        Some(credentials) => Client::new(Some(credentials), max_audio_quality),
+        Some(credentials) => Client::new(Some(credentials), max_audio_quality, legacy_streaming),
         None => {
             let (client, oauth_result) =
-                Client::new_with_oauth_login(max_audio_quality, headless).await?;
+                Client::new_with_oauth_login(max_audio_quality, legacy_streaming, headless).await?;
 
             database.set_credentials(oauth_result.into()).await?;
 

--- a/qobuz-player-client/src/client.rs
+++ b/qobuz-player-client/src/client.rs
@@ -49,6 +49,7 @@ pub struct Client {
     user_token: String,
     user_id: i64,
     max_audio_quality: AudioQuality,
+    active_secret: Option<String>,
 }
 
 #[derive(Default, Clone, Copy, Debug, clap::ValueEnum)]
@@ -186,6 +187,7 @@ enum Endpoint {
     UserPlaylist,
     Track,
     TrackURL,
+    TrackURLLegacy,
     Playlist,
     PlaylistCreate,
     PlaylistDelete,
@@ -225,6 +227,7 @@ impl Display for Endpoint {
             Endpoint::SessionStart => "session/start",
             Endpoint::Track => "track/get",
             Endpoint::TrackURL => "file/url",
+            Endpoint::TrackURLLegacy => "track/getFileUrl",
             Endpoint::UserPlaylist => "playlist/getUserPlaylists",
             Endpoint::Favorites => "favorite/getUserFavorites",
             Endpoint::FavoriteAdd => "favorite/create",
@@ -365,18 +368,30 @@ impl Client {
         user_auth_token: &str,
         user_id: i64,
         max_audio_quality: AudioQuality,
+        legacy_streaming: bool,
     ) -> Result<Client> {
         let http_client = reqwest::Client::builder()
             .cookie_store(true)
             .build()
             .expect("infallible");
 
-        let Secrets { app_id } = get_secrets(&http_client).await?;
-
-        tracing::debug!("Got login secrets, app_id: {}", app_id);
-
         let base_url = "https://www.qobuz.com/api.json/0.2/".to_string();
 
+        let (app_id, active_secret) = if legacy_streaming {
+            let LegacySecrets {
+                app_id,
+                active_secret,
+            } = get_legacy_secrets(&http_client, &base_url, user_auth_token, max_audio_quality)
+                .await?;
+            tracing::debug!("Got login secrets + active secret, app_id: {}", app_id);
+            (app_id, Some(active_secret))
+        } else {
+            let Secrets { app_id } = get_secrets(&http_client).await?;
+            tracing::debug!("Got login secrets, app_id: {}", app_id);
+            (app_id, None)
+        };
+
+        let _ = legacy_streaming; //ugly, consumed above to decide the discovery path
         let client = Client {
             http_client,
             session: None,
@@ -385,6 +400,7 @@ impl Client {
             app_id,
             base_url,
             max_audio_quality,
+            active_secret,
         };
 
         Ok(client)
@@ -763,6 +779,23 @@ impl Client {
                 message: error.to_string(),
             }),
         }
+    }
+
+    pub async fn track_url_legacy(
+        &self,
+        track_id: u32,
+    ) -> Result<crate::qobuz_models::LegacyTrackUrl> {
+        let secret = self.active_secret.as_deref().ok_or(Error::ActiveSecret)?;
+        track_url_legacy(
+            track_id,
+            secret,
+            &self.base_url,
+            &self.http_client,
+            &self.app_id,
+            &self.user_token,
+            self.max_audio_quality,
+        )
+        .await
     }
 
     pub async fn favorites(&self, limit: i32) -> Result<Favorites> {
@@ -1215,6 +1248,205 @@ async fn get_secrets(client: &reqwest::Client) -> Result<Secrets> {
         .to_owned();
 
     Ok(Secrets { app_id })
+}
+
+struct LegacySecrets {
+    app_id: String,
+    active_secret: String,
+}
+
+/// extract the app_id, per-timezone secrets, and probe for an active one
+/// tried to mirror 8cd4d7a
+async fn get_legacy_secrets(
+    client: &reqwest::Client,
+    base_url: &str,
+    user_token: &str,
+    max_audio_quality: AudioQuality,
+) -> Result<LegacySecrets> {
+    use base64::{Engine, engine::general_purpose};
+
+    let play_url = "https://play.qobuz.com";
+
+    let login_html = client
+        .get(format!("{play_url}/login"))
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await
+        .map_err(|_| Error::Login)?;
+
+    let bundle_regex = Regex::new(
+        r#"<script src="(/resources/\d+\.\d+\.\d+-[a-z0-9]\d{3}/bundle\.js)"></script>"#,
+    )
+    .map_err(|_| Error::Login)?;
+
+    let app_id_regex = Regex::new(
+        r#"production:\{api:\{appId:"(?P<app_id>\d{9})",appSecret:"(?P<app_secret>\w{32})""#,
+    )
+    .map_err(|_| Error::AppID)?;
+
+    let seed_regex = Regex::new(
+        r#"[a-z]\.initialSeed\("(?P<seed>[\w=]+)",window\.utimezone\.(?P<timezone>[a-z]+)\)"#,
+    )
+    .map_err(|_| Error::Login)?;
+
+    let bundle_path = bundle_regex
+        .captures(&login_html)
+        .and_then(|c| c.get(1))
+        .ok_or(Error::AppID)?
+        .as_str();
+
+    let bundle_html = client
+        .get(format!("{play_url}{bundle_path}"))
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await
+        .map_err(|_| Error::AppID)?;
+
+    let app_captures = app_id_regex.captures(&bundle_html).ok_or(Error::AppID)?;
+    let app_id = app_captures
+        .name("app_id")
+        .ok_or(Error::AppID)?
+        .as_str()
+        .to_owned();
+
+    let mut secrets = HashMap::new();
+
+    for seed_cap in seed_regex.captures_iter(&bundle_html) {
+        let seed = seed_cap.name("seed").ok_or(Error::Login)?.as_str();
+        let mut timezone = seed_cap
+            .name("timezone")
+            .ok_or(Error::Login)?
+            .as_str()
+            .to_owned();
+
+        capitalize(timezone.as_mut_str());
+
+        let info_re_str = format!(
+            r#"name:"\w+/(?P<timezone>{}([a-z]?))",info:"(?P<info>[\w=]+)",extras:"(?P<extras>[\w=]+)""#,
+            timezone
+        );
+        let info_re = Regex::new(&info_re_str).map_err(|_| Error::Login)?;
+
+        for c in info_re.captures_iter(&bundle_html) {
+            let tz_full = c.name("timezone").ok_or(Error::Login)?.as_str().to_owned();
+            let info = c.name("info").ok_or(Error::Login)?.as_str();
+            let extras = c.name("extras").ok_or(Error::Login)?.as_str();
+
+            let chars = format!("{seed}{info}{extras}");
+
+            if chars.len() <= 44 {
+                continue;
+            }
+
+            let encoded_secret = &chars[..chars.len() - 44];
+
+            let decoded = general_purpose::URL_SAFE
+                .decode(encoded_secret)
+                .map_err(|_| Error::Login)?;
+            let secret = std::str::from_utf8(&decoded)
+                .map_err(|_| Error::Login)?
+                .to_owned();
+
+            secrets.insert(tz_full, secret);
+        }
+    }
+
+    let active_secret = find_active_secret(
+        secrets,
+        base_url,
+        client,
+        &app_id,
+        user_token,
+        max_audio_quality,
+    )
+    .await?;
+
+    Ok(LegacySecrets {
+        app_id,
+        active_secret,
+    })
+}
+
+/// Probe each per-timezone secret with a known-good track id; the first one
+/// that returns a valid response is the active secret for our request region
+async fn find_active_secret(
+    secrets: HashMap<String, String>,
+    base_url: &str,
+    client: &reqwest::Client,
+    app_id: &str,
+    user_token: &str,
+    max_audio_quality: AudioQuality,
+) -> Result<String> {
+    tracing::debug!("probing {} timezone secrets", secrets.len());
+
+    for (timezone, secret) in secrets.into_iter() {
+        let response = track_url_legacy(
+            64868955,
+            &secret,
+            base_url,
+            client,
+            app_id,
+            user_token,
+            max_audio_quality,
+        )
+        .await;
+
+        if response.is_ok() {
+            tracing::debug!("found active secret for timezone: {}", timezone);
+            return Ok(secret);
+        }
+    }
+
+    Err(Error::ActiveSecret)
+}
+
+/// MD5 signature endpoint + sorted(param k+v concatenated) + ts + secret
+async fn track_url_legacy(
+    track_id: u32,
+    secret: &str,
+    base_url: &str,
+    client: &reqwest::Client,
+    app_id: &str,
+    user_token: &str,
+    max_audio_quality: AudioQuality,
+) -> Result<crate::qobuz_models::LegacyTrackUrl> {
+    let endpoint = format!("{}{}", base_url, Endpoint::TrackURLLegacy);
+    let now = format!("{}", time::OffsetDateTime::now_utc().unix_timestamp());
+    let quality = max_audio_quality.to_string();
+    let track_id_str = track_id.to_string();
+
+    let sig =
+        format!("trackgetFileUrlformat_id{quality}intentstreamtrack_id{track_id_str}{now}{secret}");
+    let request_sig = format!("{:x}", md5::compute(sig.as_str()));
+
+    let params = vec![
+        ("request_ts", now.as_str()),
+        ("request_sig", request_sig.as_str()),
+        ("track_id", track_id_str.as_str()),
+        ("format_id", quality.as_str()),
+        ("intent", "stream"),
+    ];
+
+    let response = make_get_call(
+        &endpoint,
+        Some(&params),
+        client,
+        app_id,
+        Some(user_token),
+        None,
+    )
+    .await?;
+    serde_json::from_str(&response).map_err(|_| Error::DeserializeJSON { message: response })
+}
+
+fn capitalize(s: &mut str) {
+    if let Some(r) = s.get_mut(0..1) {
+        r.make_ascii_uppercase();
+    }
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]

--- a/qobuz-player-client/src/client.rs
+++ b/qobuz-player-client/src/client.rs
@@ -798,6 +798,40 @@ impl Client {
         .await
     }
 
+    /// Stream a plaintext FLAC/MP3 from a legacy signed URL
+    /// Uses stream-download re-exported reqwest (0.13, diff from workspace reqwest 0.12)
+    pub async fn stream_track_legacy(&self, url: &str) -> Result<SeekableStreamReader> {
+        use stream_download::http::HttpStream;
+        use stream_download::http::reqwest::{Client as SdClient, Url as SdUrl};
+        use stream_download::source::SourceStream;
+
+        let url_parsed: SdUrl = url
+            .parse()
+            .map_err(|e: url::ParseError| Error::StreamError {
+                message: format!("invalid legacy track URL: {e}"),
+            })?;
+
+        let stream = HttpStream::new(SdClient::new(), url_parsed)
+            .await
+            .map_err(|e| Error::StreamError {
+                message: format!("failed to open HTTP stream: {e}"),
+            })?;
+
+        let content_length = stream.content_length().unwrap_or(0);
+
+        let reader = StreamDownload::from_stream(
+            stream,
+            TempStorageProvider::default(),
+            Settings::default().prefetch_bytes(64 * 1024),
+        )
+        .await
+        .map_err(|e| Error::StreamError {
+            message: format!("failed to create stream-download: {e}"),
+        })?;
+
+        Ok(SeekableStreamReader::new(reader, content_length))
+    }
+
     pub async fn favorites(&self, limit: i32) -> Result<Favorites> {
         let endpoint = format!("{}{}", self.base_url, Endpoint::Favorites);
 

--- a/qobuz-player-client/src/client.rs
+++ b/qobuz-player-client/src/client.rs
@@ -798,12 +798,16 @@ impl Client {
         .await
     }
 
-    /// Stream a plaintext FLAC/MP3 from a legacy signed URL
-    /// Uses stream-download re-exported reqwest (0.13, diff from workspace reqwest 0.12)
-    pub async fn stream_track_legacy(&self, url: &str) -> Result<SeekableStreamReader> {
+    pub async fn stream_track_legacy(
+        &self,
+        url: &str,
+        cache_path: &std::path::Path,
+    ) -> Result<SeekableStreamReader> {
         use stream_download::http::HttpStream;
         use stream_download::http::reqwest::{Client as SdClient, Url as SdUrl};
         use stream_download::source::SourceStream;
+
+        use crate::stream::passthrough_storage::PassthroughStorageProvider;
 
         let url_parsed: SdUrl = url
             .parse()
@@ -819,9 +823,14 @@ impl Client {
 
         let content_length = stream.content_length().unwrap_or(0);
 
-        let reader = StreamDownload::from_stream(
+        let partial_path = cache_path.with_extension("partial");
+        let provider = PassthroughStorageProvider {
+            partial_path: partial_path.clone(),
+        };
+
+        let download = StreamDownload::from_stream(
             stream,
-            TempStorageProvider::default(),
+            provider,
             Settings::default().prefetch_bytes(64 * 1024),
         )
         .await
@@ -829,7 +838,16 @@ impl Client {
             message: format!("failed to create stream-download: {e}"),
         })?;
 
-        Ok(SeekableStreamReader::new(reader, content_length))
+        if content_length > 0 {
+            let handle = download.handle();
+            let final_path = cache_path.to_path_buf();
+            tokio::spawn(async move {
+                handle.wait_for_completion().await;
+                finalize_legacy_cache(partial_path, final_path, content_length);
+            });
+        }
+
+        Ok(SeekableStreamReader::new(download, content_length))
     }
 
     pub async fn favorites(&self, limit: i32) -> Result<Favorites> {
@@ -1486,4 +1504,30 @@ fn capitalize(s: &mut str) {
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct SuccessfulResponse {
     status: String,
+}
+
+fn finalize_legacy_cache(partial: PathBuf, final_path: PathBuf, expected: u64) {
+    match std::fs::metadata(&partial) {
+        Ok(meta) if meta.len() == expected => {
+            if let Err(e) = std::fs::rename(&partial, &final_path) {
+                tracing::warn!("Failed to finalize legacy cache: {e}");
+                let _ = std::fs::remove_file(&partial);
+            } else {
+                tracing::info!(
+                    "Cached (legacy): {} ({} bytes)",
+                    final_path.display(),
+                    expected
+                );
+            }
+        }
+        Ok(meta) => {
+            tracing::debug!(
+                "Legacy stream incomplete ({} of {} bytes), discarding partial",
+                meta.len(),
+                expected
+            );
+            let _ = std::fs::remove_file(&partial);
+        }
+        Err(_) => {}
+    }
 }

--- a/qobuz-player-client/src/qobuz_models.rs
+++ b/qobuz-player-client/src/qobuz_models.rs
@@ -45,6 +45,15 @@ pub struct TrackInfo {
     pub n_samples: Option<u64>,
 }
 
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct LegacyTrackUrl {
+    pub url: String,
+    pub format_id: i32,
+    pub mime_type: String,
+    pub sampling_rate: f64,
+    pub bit_depth: i32,
+}
+
 pub enum UrlType {
     Album { id: String },
     Playlist { id: i64 },

--- a/qobuz-player-client/src/stream.rs
+++ b/qobuz-player-client/src/stream.rs
@@ -3,6 +3,7 @@ use crate::Error;
 pub mod cmaf;
 pub mod crypto;
 pub mod flac_source_stream;
+pub mod passthrough_storage;
 
 pub async fn fetch_segment(url: &str, index: u8) -> Result<Vec<u8>, Error> {
     let bytes = reqwest::get(url)

--- a/qobuz-player-client/src/stream/flac_source_stream.rs
+++ b/qobuz-player-client/src/stream/flac_source_stream.rs
@@ -13,11 +13,7 @@ use std::{
 use bytes::Bytes;
 use futures::Stream;
 use parking_lot::Mutex;
-use stream_download::{
-    StreamDownload,
-    source::{DecodeError, SourceStream, StreamOutcome},
-    storage::temp::TempStorageProvider,
-};
+use stream_download::source::{DecodeError, SourceStream, StreamOutcome};
 use tokio::task::JoinHandle;
 
 use crate::stream::{cmaf, crypto};
@@ -164,16 +160,18 @@ impl Stream for FlacSourceStream {
     }
 }
 
-/// Wraps `StreamDownload` with `SeekFrom::End` support using known content length.
 pub struct SeekableStreamReader {
-    inner: StreamDownload<TempStorageProvider>,
+    inner: Box<dyn ReadSeekSend>,
     content_length: u64,
 }
 
+pub trait ReadSeekSend: Read + Seek + Send + Sync {}
+impl<T: Read + Seek + Send + Sync + 'static> ReadSeekSend for T {}
+
 impl SeekableStreamReader {
-    pub fn new(inner: StreamDownload<TempStorageProvider>, content_length: u64) -> Self {
+    pub fn new<R: Read + Seek + Send + Sync + 'static>(inner: R, content_length: u64) -> Self {
         Self {
-            inner,
+            inner: Box::new(inner),
             content_length,
         }
     }

--- a/qobuz-player-client/src/stream/passthrough_storage.rs
+++ b/qobuz-player-client/src/stream/passthrough_storage.rs
@@ -1,0 +1,29 @@
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::path::PathBuf;
+
+use stream_download::storage::StorageProvider;
+
+pub struct PassthroughStorageProvider {
+    pub partial_path: PathBuf,
+}
+
+impl StorageProvider for PassthroughStorageProvider {
+    type Reader = File;
+    type Writer = File;
+
+    fn into_reader_writer(self, _content_length: Option<u64>) -> io::Result<(File, File)> {
+        if let Some(parent) = self.partial_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let writer = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&self.partial_path)?;
+        // Independent fd with its own position. `try_clone` shares position
+        // with the writer, which would corrupt streamed reads.
+        let reader = OpenOptions::new().read(true).open(&self.partial_path)?;
+        Ok((reader, writer))
+    }
+}

--- a/qobuz-player-client/tests/integration_test.rs
+++ b/qobuz-player-client/tests/integration_test.rs
@@ -15,6 +15,7 @@ async fn get_client() -> Option<Client> {
         &credentials.user_auth_token,
         credentials.user_id,
         qobuz_player_client::client::AudioQuality::Mp3,
+        false,
     )
     .await
     .ok()

--- a/qobuz-player-connect/src/main.rs
+++ b/qobuz-player-connect/src/main.rs
@@ -55,7 +55,13 @@ pub async fn run() -> AppResult<()> {
     let (_, exit_receiver) = broadcast::channel(5);
 
     let max_audio_quality = default_audio_quality(&database, args.shared.max_audio_quality).await?;
-    let client = get_client(&database, max_audio_quality, headless).await?;
+    let client = get_client(
+        &database,
+        max_audio_quality,
+        args.shared.legacy_streaming,
+        headless,
+    )
+    .await?;
     let client = Arc::new(client);
 
     let broadcast = Arc::new(NotificationBroadcast::new());

--- a/qobuz-player-controls/src/client.rs
+++ b/qobuz-player-controls/src/client.rs
@@ -210,9 +210,13 @@ impl Client {
         Ok(info)
     }
 
-    pub async fn stream_track_legacy(&self, url: &str) -> Result<SeekableStreamReader> {
+    pub async fn stream_track_legacy(
+        &self,
+        url: &str,
+        cache_path: &std::path::Path,
+    ) -> Result<SeekableStreamReader> {
         let client = self.get_client().await?;
-        let stream = client.stream_track_legacy(url).await?;
+        let stream = client.stream_track_legacy(url, cache_path).await?;
         Ok(stream)
     }
 

--- a/qobuz-player-controls/src/client.rs
+++ b/qobuz-player-controls/src/client.rs
@@ -210,6 +210,12 @@ impl Client {
         Ok(info)
     }
 
+    pub async fn stream_track_legacy(&self, url: &str) -> Result<SeekableStreamReader> {
+        let client = self.get_client().await?;
+        let stream = client.stream_track_legacy(url).await?;
+        Ok(stream)
+    }
+
     pub async fn stream_track(
         &self,
         cache_path: PathBuf,

--- a/qobuz-player-controls/src/client.rs
+++ b/qobuz-player-controls/src/client.rs
@@ -18,7 +18,7 @@ use qobuz_player_client::{
         AudioQuality, FeaturedAlbumType, FeaturedGenreAlbumType, FeaturedPlaylistType, OAuthResult,
         ReleaseType, browser_oauth_login,
     },
-    qobuz_models::TrackInfo,
+    qobuz_models::{LegacyTrackUrl, TrackInfo},
     stream::flac_source_stream::SeekableStreamReader,
 };
 use time::Duration;
@@ -39,6 +39,7 @@ pub struct Client {
     qobuz_client: OnceCell<RwLock<QobuzClient>>,
     credentials: Mutex<Option<Credentials>>,
     max_audio_quality: RwLock<AudioQuality>,
+    legacy_streaming: bool,
     favorites_cache: SimpleCache<Favorites>,
     featured_albums_cache: SimpleCache<Vec<(String, Vec<AlbumSimple>)>>,
     featured_playlists_cache: SimpleCache<Vec<(String, Vec<Playlist>)>>,
@@ -70,6 +71,7 @@ impl Client {
 
     pub async fn new_with_oauth_login(
         max_audio_quality: AudioQuality,
+        legacy_streaming: bool,
         headless: bool,
     ) -> Result<(Self, OAuthResult)> {
         let app_id = get_app_id().await?;
@@ -80,12 +82,21 @@ impl Client {
                 user_id: oauth_result.user_id,
             }),
             max_audio_quality,
+            legacy_streaming,
         );
 
         Ok((client, oauth_result))
     }
 
-    pub fn new(credentials: Option<Credentials>, max_audio_quality: AudioQuality) -> Self {
+    pub fn is_legacy_streaming(&self) -> bool {
+        self.legacy_streaming
+    }
+
+    pub fn new(
+        credentials: Option<Credentials>,
+        max_audio_quality: AudioQuality,
+        legacy_streaming: bool,
+    ) -> Self {
         let album_cache = moka::future::CacheBuilder::new(1000)
             .time_to_live(std::time::Duration::from_secs(60 * 60 * 24 * 7))
             .build();
@@ -121,6 +132,7 @@ impl Client {
             qobuz_client: Default::default(),
             credentials,
             max_audio_quality,
+            legacy_streaming,
             favorites_cache: SimpleCache::new(Duration::days(1)),
             featured_albums_cache: SimpleCache::new(Duration::days(1)),
             featured_playlists_cache: SimpleCache::new(Duration::days(1)),
@@ -150,6 +162,7 @@ impl Client {
             &credentials.user_auth_token,
             credentials.user_id,
             *max_audio_quality,
+            self.legacy_streaming,
         )
         .await?;
 
@@ -188,6 +201,12 @@ impl Client {
     pub async fn track_url(&self, track_id: u32) -> Result<TrackInfo> {
         let mut client = self.get_client_mut().await?;
         let info = client.track_url(track_id).await?;
+        Ok(info)
+    }
+
+    pub async fn track_url_legacy(&self, track_id: u32) -> Result<LegacyTrackUrl> {
+        let client = self.get_client().await?;
+        let info = client.track_url_legacy(track_id).await?;
         Ok(info)
     }
 

--- a/qobuz-player-controls/src/downloader.rs
+++ b/qobuz-player-controls/src/downloader.rs
@@ -78,7 +78,10 @@ impl Downloader {
         }
 
         tracing::info!("Streaming (legacy): {}", track.title);
-        let stream = self.client.stream_track_legacy(&track_url.url).await?;
+        let stream = self
+            .client
+            .stream_track_legacy(&track_url.url, &cache_path)
+            .await?;
         Ok(DownloadResult::Streaming(stream))
     }
 

--- a/qobuz-player-controls/src/downloader.rs
+++ b/qobuz-player-controls/src/downloader.rs
@@ -5,7 +5,7 @@ use std::{
 
 use qobuz_player_client::stream::flac_source_stream::SeekableStreamReader;
 
-use crate::{AppResult, client::Client, database::Database, models::Track};
+use crate::{AppResult, client::Client, database::Database, error::Error, models::Track};
 
 pub enum DownloadResult {
     Cached(PathBuf),
@@ -32,6 +32,10 @@ impl Downloader {
     }
 
     pub async fn ensure_track_is_downloaded(&mut self, track: &Track) -> AppResult<DownloadResult> {
+        if self.client.is_legacy_streaming() {
+            return self.ensure_track_is_downloaded_legacy(track).await;
+        }
+
         let track_info = self.client.track_url(track.id).await?;
 
         let cache_path = cache_path(
@@ -50,6 +54,32 @@ impl Downloader {
         let stream = self.client.stream_track(cache_path, track_info).await?;
 
         Ok(DownloadResult::Streaming(stream))
+    }
+
+    /// Legacy path: cheap cpu as no crypto ops
+    /// cons have to wait for full download
+    async fn ensure_track_is_downloaded_legacy(
+        &mut self,
+        track: &Track,
+    ) -> AppResult<DownloadResult> {
+        let track_url = self.client.track_url_legacy(track.id).await?;
+
+        let cache_path = cache_path(
+            track,
+            &track_url.mime_type,
+            Some(track_url.sampling_rate as u32),
+            &self.audio_cache_directory,
+        );
+        self.database.set_cache_entry(cache_path.as_path()).await;
+
+        if cache_path.exists() {
+            tracing::info!("Playing from cache: {}", cache_path.display());
+            return Ok(DownloadResult::Cached(cache_path));
+        }
+
+        tracing::info!("Downloading (legacy): {}", track.title);
+        download_to_file(&track_url.url, &cache_path).await?;
+        Ok(DownloadResult::Cached(cache_path))
     }
 
     pub fn set_audio_cache_dir(&mut self, new_directory: PathBuf) {
@@ -142,4 +172,18 @@ fn guess_extension(mime: &str) -> String {
         m if m.contains("mp3") => "mp3".to_string(),
         _ => "unknown".to_string(),
     }
+}
+
+async fn download_to_file(url: &str, cache_path: &Path) -> AppResult<()> {
+    let bytes = reqwest::get(url).await?.bytes().await?;
+    let io_err = |e: std::io::Error| Error::StreamError {
+        message: format!("legacy download write failed: {e}"),
+    };
+    if let Some(parent) = cache_path.parent() {
+        std::fs::create_dir_all(parent).map_err(io_err)?;
+    }
+    let tmp = cache_path.with_extension("partial");
+    std::fs::write(&tmp, &bytes).map_err(io_err)?;
+    std::fs::rename(&tmp, cache_path).map_err(io_err)?;
+    Ok(())
 }

--- a/qobuz-player-controls/src/downloader.rs
+++ b/qobuz-player-controls/src/downloader.rs
@@ -5,7 +5,7 @@ use std::{
 
 use qobuz_player_client::stream::flac_source_stream::SeekableStreamReader;
 
-use crate::{AppResult, client::Client, database::Database, error::Error, models::Track};
+use crate::{AppResult, client::Client, database::Database, models::Track};
 
 pub enum DownloadResult {
     Cached(PathBuf),
@@ -57,7 +57,7 @@ impl Downloader {
     }
 
     /// Legacy path: cheap cpu as no crypto ops
-    /// cons have to wait for full download
+    /// Cache hits from prior runs still work; cache writeback during streaming is not yet implemented
     async fn ensure_track_is_downloaded_legacy(
         &mut self,
         track: &Track,
@@ -77,9 +77,9 @@ impl Downloader {
             return Ok(DownloadResult::Cached(cache_path));
         }
 
-        tracing::info!("Downloading (legacy): {}", track.title);
-        download_to_file(&track_url.url, &cache_path).await?;
-        Ok(DownloadResult::Cached(cache_path))
+        tracing::info!("Streaming (legacy): {}", track.title);
+        let stream = self.client.stream_track_legacy(&track_url.url).await?;
+        Ok(DownloadResult::Streaming(stream))
     }
 
     pub fn set_audio_cache_dir(&mut self, new_directory: PathBuf) {
@@ -172,18 +172,4 @@ fn guess_extension(mime: &str) -> String {
         m if m.contains("mp3") => "mp3".to_string(),
         _ => "unknown".to_string(),
     }
-}
-
-async fn download_to_file(url: &str, cache_path: &Path) -> AppResult<()> {
-    let bytes = reqwest::get(url).await?.bytes().await?;
-    let io_err = |e: std::io::Error| Error::StreamError {
-        message: format!("legacy download write failed: {e}"),
-    };
-    if let Some(parent) = cache_path.parent() {
-        std::fs::create_dir_all(parent).map_err(io_err)?;
-    }
-    let tmp = cache_path.with_extension("partial");
-    std::fs::write(&tmp, &bytes).map_err(io_err)?;
-    std::fs::rename(&tmp, cache_path).map_err(io_err)?;
-    Ok(())
 }

--- a/qobuz-player-gtk/src/main.rs
+++ b/qobuz-player-gtk/src/main.rs
@@ -33,7 +33,12 @@ pub async fn run() -> AppResult<()> {
     let configuration = database.get_configuration().await?;
 
     let app_id = get_app_id().await?;
-    let client = Arc::new(Client::new(credentials, configuration.max_audio_quality));
+    // TODO: --legacy-streaming as a setting in the GTK UI ??
+    let client = Arc::new(Client::new(
+        credentials,
+        configuration.max_audio_quality,
+        false,
+    ));
 
     let broadcast = Arc::new(NotificationBroadcast::new());
 

--- a/qobuz-player-rfid/src/main.rs
+++ b/qobuz-player-rfid/src/main.rs
@@ -59,7 +59,13 @@ pub async fn run() -> AppResult<()> {
     let (_, exit_receiver) = broadcast::channel(5);
 
     let max_audio_quality = default_audio_quality(&database, args.shared.max_audio_quality).await?;
-    let client = get_client(&database, max_audio_quality, headless).await?;
+    let client = get_client(
+        &database,
+        max_audio_quality,
+        args.shared.legacy_streaming,
+        headless,
+    )
+    .await?;
     let client = Arc::new(client);
 
     let broadcast = Arc::new(NotificationBroadcast::new());

--- a/qobuz-player-tui/src/main.rs
+++ b/qobuz-player-tui/src/main.rs
@@ -53,7 +53,13 @@ pub async fn run() -> AppResult<()> {
     let (exit_sender, exit_receiver) = broadcast::channel(5);
 
     let max_audio_quality = default_audio_quality(&database, args.shared.max_audio_quality).await?;
-    let client = get_client(&database, max_audio_quality, headless).await?;
+    let client = get_client(
+        &database,
+        max_audio_quality,
+        args.shared.legacy_streaming,
+        headless,
+    )
+    .await?;
     let client = Arc::new(client);
 
     let broadcast = Arc::new(NotificationBroadcast::new());

--- a/qobuz-player-web/src/main.rs
+++ b/qobuz-player-web/src/main.rs
@@ -73,7 +73,13 @@ pub async fn run() -> AppResult<()> {
     let (_, exit_receiver) = broadcast::channel(5);
 
     let max_audio_quality = default_audio_quality(&database, args.shared.max_audio_quality).await?;
-    let client = get_client(&database, max_audio_quality, headless).await?;
+    let client = get_client(
+        &database,
+        max_audio_quality,
+        args.shared.legacy_streaming,
+        headless,
+    )
+    .await?;
     let client = Arc::new(client);
 
     let broadcast = Arc::new(NotificationBroadcast::new());


### PR DESCRIPTION
Can solve https://github.com/SofusA/qobine/issues/357

Re-add the old track url api, with streaming on top. To test: `--legacy-streaming`

Current cons I did not went through yet: 
- cache hits from prior runs still work; cache writeback during streaming is not yet implemented
- not accessible via the gtk app