### PR TITLE
TUI tweaks for Favorites/Tracks

### DIFF
--- a/qobuz-player-client/src/qobuz_models/track.rs
+++ b/qobuz-player-client/src/qobuz_models/track.rs
@@ -21,6 +21,8 @@ pub struct Track {
     pub track_number: u32,
     pub parental_warning: bool,
     pub playlist_track_id: Option<u64>,
+    #[serde(default)]
+    pub favorited_at: Option<i64>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/qobuz-player-controls/src/client.rs
+++ b/qobuz-player-controls/src/client.rs
@@ -460,14 +460,13 @@ impl Client {
 
         playlists.sort_by_key(|a| a.title.to_lowercase());
 
-        let mut tracks: Vec<_> = favorites_result
-            .tracks
-            .items
+        let mut track_items = favorites_result.tracks.items;
+        track_items.sort_by_key(|t| std::cmp::Reverse(t.favorited_at));
+
+        let tracks: Vec<_> = track_items
             .into_iter()
             .map(|x| parse_track(x, &audio_quality))
             .collect();
-
-        tracks.sort_by_key(|a| a.title.to_lowercase());
 
         let favorites = Favorites {
             albums,

--- a/qobuz-player-tui/src/app.rs
+++ b/qobuz-player-tui/src/app.rs
@@ -22,7 +22,7 @@ use qobuz_player_controls::{
 };
 use ratatui::{DefaultTerminal, widgets::*};
 use ratatui_image::protocol::StatefulProtocol;
-use std::{io, sync::Arc, time::Instant};
+use std::{collections::HashSet, io, sync::Arc, time::Instant};
 use tokio::time::{self, Duration};
 
 #[derive(Default)]
@@ -71,6 +71,14 @@ pub struct App {
     pub full_screen: bool,
     pub disable_tui_album_cover: bool,
     pub current_image_url: Option<String>,
+    pub favorite_ids: FavoriteIds,
+}
+
+#[derive(Default)]
+pub struct FavoriteIds {
+    pub tracks: HashSet<u32>,
+    pub albums: HashSet<String>,
+    pub artists: HashSet<u32>,
 }
 
 #[derive(Default)]
@@ -278,11 +286,15 @@ impl App {
         Ok(())
     }
 
-    async fn update_favorites(&mut self) {
+    pub(crate) async fn update_favorites(&mut self) {
         let favorites = self.client.favorites().await;
         let Ok(favorites) = favorites else {
             return;
         };
+
+        self.favorite_ids.tracks = favorites.tracks.iter().map(|t| t.id).collect();
+        self.favorite_ids.albums = favorites.albums.iter().map(|a| a.id.clone()).collect();
+        self.favorite_ids.artists = favorites.artists.iter().map(|a| a.id).collect();
 
         self.favorites.albums.set_all_items(favorites.albums);
         self.favorites.artists.set_all_items(favorites.artists);

--- a/qobuz-player-tui/src/app.rs
+++ b/qobuz-player-tui/src/app.rs
@@ -541,7 +541,16 @@ impl App {
                             )
                             .await
                     }
-                    Tab::Queue => Ok(self.queue.handle_events(event, &self.controls).await),
+                    Tab::Queue => {
+                        self.queue
+                            .handle_events(
+                                event,
+                                &self.client,
+                                &self.controls,
+                                &mut self.notifications,
+                            )
+                            .await
+                    }
                     Tab::Discover => {
                         self.discover
                             .handle_events(

--- a/qobuz-player-tui/src/app.rs
+++ b/qobuz-player-tui/src/app.rs
@@ -16,7 +16,7 @@ use qobuz_player_controls::{
     AppResult, PositionReceiver, Status, StatusReceiver, TracklistReceiver,
     client::Client,
     controls::Controls,
-    models::Track,
+    models::{AlbumSimple, Artist, Track},
     notification::{Notification, NotificationBroadcast},
     tracklist::{Tracklist, TracklistType},
 };
@@ -94,10 +94,24 @@ pub enum Output {
     Consumed,
     NotConsumed,
     UpdateFavorites,
+    FavoriteAdded(FavoriteAdd),
+    FavoriteRemoved(FavoriteRemove),
     Popup(Popup),
     PopPopupUpdateFavorites,
     AddTrackToPlaylistPopup(Track),
     AddTrackToPlaylistAndPopPopup((u32, u32)), // TODO: Add a type
+}
+
+pub enum FavoriteAdd {
+    Track(Track),
+    Album(AlbumSimple),
+    Artist(Artist),
+}
+
+pub enum FavoriteRemove {
+    Track(u32),
+    Album(String),
+    Artist(u32),
 }
 
 #[derive(Default, PartialEq)]
@@ -305,6 +319,79 @@ impl App {
         self.favorites.filter.reset();
     }
 
+    fn apply_favorite_added(&mut self, added: FavoriteAdd) {
+        match added {
+            FavoriteAdd::Track(track) => {
+                self.favorite_ids.tracks.insert(track.id);
+                let mut items = self.favorites.tracks.all_items().clone();
+                items.insert(0, track);
+                self.favorites.tracks.set_all_items(items);
+            }
+            FavoriteAdd::Album(album) => {
+                self.favorite_ids.albums.insert(album.id.clone());
+                let mut items = self.favorites.albums.all_items().clone();
+                items.push(album);
+                items.sort_by(|a, b| {
+                    a.artist
+                        .name
+                        .to_lowercase()
+                        .cmp(&b.artist.name.to_lowercase())
+                });
+                self.favorites.albums.set_all_items(items);
+            }
+            FavoriteAdd::Artist(artist) => {
+                self.favorite_ids.artists.insert(artist.id);
+                let mut items = self.favorites.artists.all_items().clone();
+                items.push(artist);
+                items.sort_by_key(|a| a.name.to_lowercase());
+                self.favorites.artists.set_all_items(items);
+            }
+        }
+        self.favorites.filter.reset();
+    }
+
+    fn apply_favorite_removed(&mut self, removed: FavoriteRemove) {
+        match removed {
+            FavoriteRemove::Track(id) => {
+                self.favorite_ids.tracks.remove(&id);
+                let items: Vec<_> = self
+                    .favorites
+                    .tracks
+                    .all_items()
+                    .iter()
+                    .filter(|t| t.id != id)
+                    .cloned()
+                    .collect();
+                self.favorites.tracks.set_all_items(items);
+            }
+            FavoriteRemove::Album(id) => {
+                self.favorite_ids.albums.remove(&id);
+                let items: Vec<_> = self
+                    .favorites
+                    .albums
+                    .all_items()
+                    .iter()
+                    .filter(|a| a.id != id)
+                    .cloned()
+                    .collect();
+                self.favorites.albums.set_all_items(items);
+            }
+            FavoriteRemove::Artist(id) => {
+                self.favorite_ids.artists.remove(&id);
+                let items: Vec<_> = self
+                    .favorites
+                    .artists
+                    .all_items()
+                    .iter()
+                    .filter(|a| a.id != id)
+                    .cloned()
+                    .collect();
+                self.favorites.artists.set_all_items(items);
+            }
+        }
+        self.favorites.filter.reset();
+    }
+
     async fn handle_output(&mut self, key_code: KeyCode, output: AppResult<Output>) {
         let output = match output {
             Ok(res) => res,
@@ -321,6 +408,14 @@ impl App {
             }
             Output::UpdateFavorites => {
                 self.update_favorites().await;
+                self.should_draw = true;
+            }
+            Output::FavoriteAdded(added) => {
+                self.apply_favorite_added(added);
+                self.should_draw = true;
+            }
+            Output::FavoriteRemoved(removed) => {
+                self.apply_favorite_removed(removed);
                 self.should_draw = true;
             }
             Output::NotConsumed => match key_code {

--- a/qobuz-player-tui/src/discover.rs
+++ b/qobuz-player-tui/src/discover.rs
@@ -10,7 +10,7 @@ use ratatui::{
 
 use crate::ui::sidebar;
 use crate::{
-    app::{NotificationList, Output},
+    app::{FavoriteIds, NotificationList, Output},
     ui::block,
     widgets::{album_list::AlbumList, playlist_list::PlaylistList},
 };
@@ -81,7 +81,7 @@ impl DiscoverState {
         })
     }
 
-    pub fn render(&mut self, frame: &mut Frame, area: Rect) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, favorite_ids: &FavoriteIds) {
         let block = block(None);
         frame.render_widget(block, area);
 
@@ -113,7 +113,12 @@ impl DiscoverState {
         let content_focused = self.focus == DiscoverFocus::Content;
 
         if let Some((_, list)) = self.selected_album_mut() {
-            list.render(chunks[1], frame.buffer_mut(), content_focused);
+            list.render(
+                chunks[1],
+                frame.buffer_mut(),
+                content_focused,
+                &favorite_ids.albums,
+            );
         } else if let Some((_, list)) = self.selected_playlist_mut() {
             list.render(chunks[1], frame.buffer_mut(), content_focused);
         }

--- a/qobuz-player-tui/src/favorites.rs
+++ b/qobuz-player-tui/src/favorites.rs
@@ -7,7 +7,7 @@ use ratatui::{
 use tui_input::{Input, backend::crossterm::EventHandler};
 
 use crate::{
-    app::{NotificationList, Output},
+    app::{FavoriteIds, NotificationList, Output},
     sub_tab::SubTab,
     ui::{block, render_input, sidebar},
     widgets::{
@@ -54,7 +54,7 @@ impl FavoritesState {
         })
     }
 
-    pub fn render(&mut self, frame: &mut Frame, area: Rect) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, favorite_ids: &FavoriteIds) {
         let tab_content_area_split = Layout::default()
             .constraints([Constraint::Length(3), Constraint::Min(1)])
             .split(area);
@@ -87,20 +87,29 @@ impl FavoritesState {
 
         let content_focused = self.focus == FavoritesFocus::Content;
         match self.sub_tab {
-            SubTab::Albums => self
-                .albums
-                .render(chunks[1], frame.buffer_mut(), content_focused),
-            SubTab::Artists => self
-                .artists
-                .render(chunks[1], frame.buffer_mut(), content_focused),
+            SubTab::Albums => self.albums.render(
+                chunks[1],
+                frame.buffer_mut(),
+                content_focused,
+                &favorite_ids.albums,
+            ),
+            SubTab::Artists => self.artists.render(
+                chunks[1],
+                frame.buffer_mut(),
+                content_focused,
+                &favorite_ids.artists,
+            ),
             SubTab::Playlists => {
                 self.playlists
                     .render(chunks[1], frame.buffer_mut(), content_focused)
             }
-            SubTab::Tracks => {
-                self.tracks
-                    .render(chunks[1], frame.buffer_mut(), true, content_focused)
-            }
+            SubTab::Tracks => self.tracks.render(
+                chunks[1],
+                frame.buffer_mut(),
+                true,
+                content_focused,
+                &favorite_ids.tracks,
+            ),
         };
     }
 

--- a/qobuz-player-tui/src/genres.rs
+++ b/qobuz-player-tui/src/genres.rs
@@ -10,7 +10,7 @@ use ratatui::{
 
 use crate::ui::{SELECTED_STYLE, sidebar};
 use crate::{
-    app::{NotificationList, Output},
+    app::{FavoriteIds, NotificationList, Output},
     ui::block,
     widgets::{album_list::AlbumList, playlist_list::PlaylistList},
 };
@@ -116,7 +116,7 @@ impl GenresState {
         Ok(())
     }
 
-    pub fn render(&mut self, frame: &mut Frame, area: Rect) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, favorite_ids: &FavoriteIds) {
         let block = block(None);
         frame.render_widget(block, area);
 
@@ -124,7 +124,7 @@ impl GenresState {
 
         match self.mode {
             GenresMode::GenreList => self.render_genre_list(frame, content_area),
-            GenresMode::GenreDetail => self.render_genre_detail(frame, content_area),
+            GenresMode::GenreDetail => self.render_genre_detail(frame, content_area, favorite_ids),
         }
     }
 
@@ -189,7 +189,7 @@ impl GenresState {
         }
     }
 
-    fn render_genre_detail(&mut self, frame: &mut Frame, area: Rect) {
+    fn render_genre_detail(&mut self, frame: &mut Frame, area: Rect, favorite_ids: &FavoriteIds) {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([Constraint::Length(2), Constraint::Min(1)])
@@ -230,7 +230,12 @@ impl GenresState {
         let content_focused = self.focus == GenresFocus::Content;
         match self.selected_mut() {
             Some(Selected::Album(list)) => {
-                list.render(content_chunks[1], frame.buffer_mut(), content_focused);
+                list.render(
+                    content_chunks[1],
+                    frame.buffer_mut(),
+                    content_focused,
+                    &favorite_ids.albums,
+                );
             }
             Some(Selected::Playlist(list)) => {
                 list.render(content_chunks[1], frame.buffer_mut(), content_focused);

--- a/qobuz-player-tui/src/lib.rs
+++ b/qobuz-player-tui/src/lib.rs
@@ -113,7 +113,11 @@ fn draw_loading_screen<B: Backend>(terminal: &mut Terminal<B>) {
 
     terminal
         .draw(|f| {
-            let area = center(f.area(), Constraint::Length(width), Constraint::Length(height));
+            let area = center(
+                f.area(),
+                Constraint::Length(width),
+                Constraint::Length(height),
+            );
             let paragraph = Paragraph::new(ascii_art).alignment(Alignment::Left);
             f.render_widget(paragraph, area);
         })

--- a/qobuz-player-tui/src/lib.rs
+++ b/qobuz-player-tui/src/lib.rs
@@ -82,7 +82,10 @@ pub async fn init(
             database,
         ),
         client,
+        favorite_ids: Default::default(),
     };
+
+    app.update_favorites().await;
 
     _ = app.run(&mut terminal).await;
     ratatui::restore();
@@ -93,20 +96,25 @@ pub async fn init(
 
 fn draw_loading_screen<B: Backend>(terminal: &mut Terminal<B>) {
     let ascii_art = r#"
-             _                     _                       
-  __ _  ___ | |__  _   _ _____ __ | | __ _ _   _  ___ _ __ 
+             _                     _
+  __ _  ___ | |__  _   _ _____ __ | | __ _ _   _  ___ _ __
  / _` |/ _ \| '_ \| | | |_  / '_ \| |/ _` | | | |/ _ \ '__|
-| (_| | (_) | |_) | |_| |/ /| |_) | | (_| | |_| |  __/ |   
- \__, |\___/|_.__/ \__,_/___| .__/|_|\__,_|\__, |\___|_|   
-    |_|                     |_|            |___/           
+| (_| | (_) | |_) | |_| |/ /| |_) | | (_| | |_| |  __/ |
+ \__, |\___/|_.__/ \__,_/___| .__/|_|\__,_|\__, |\___|_|
+    |_|                     |_|            |___/
 "#;
+
+    let width = ascii_art
+        .lines()
+        .map(|line| line.chars().count())
+        .max()
+        .unwrap_or(0) as u16;
+    let height = ascii_art.lines().count() as u16;
 
     terminal
         .draw(|f| {
-            let area = center(f.area(), Constraint::Length(64), Constraint::Length(7));
-            let paragraph = Paragraph::new(ascii_art)
-                .alignment(Alignment::Center)
-                .wrap(Wrap { trim: false });
+            let area = center(f.area(), Constraint::Length(width), Constraint::Length(height));
+            let paragraph = Paragraph::new(ascii_art).alignment(Alignment::Left);
             f.render_widget(paragraph, area);
         })
         .expect("infallible");

--- a/qobuz-player-tui/src/popup.rs
+++ b/qobuz-player-tui/src/popup.rs
@@ -13,7 +13,7 @@ use ratatui_image::{StatefulImage, protocol::StatefulProtocol};
 use tui_input::{Input, backend::crossterm::EventHandler};
 
 use crate::{
-    app::{NotificationList, Output},
+    app::{FavoriteIds, NotificationList, Output},
     ui::{block, center, centered_rect_fixed, format_seconds, render_input, tab_bar},
     widgets::{
         album_list::AlbumList,
@@ -279,7 +279,7 @@ pub enum Popup {
 }
 
 impl Popup {
-    pub fn render(&mut self, frame: &mut Frame) {
+    pub fn render(&mut self, frame: &mut Frame, favorite_ids: &FavoriteIds) {
         match self {
             Popup::Album(state) => {
                 let area = center(
@@ -292,9 +292,13 @@ impl Popup {
 
                 frame.render_widget(Clear, area);
                 frame.render_widget(&block, area);
-                state
-                    .tracks
-                    .render(block.inner(area), frame.buffer_mut(), false, true);
+                state.tracks.render(
+                    block.inner(area),
+                    frame.buffer_mut(),
+                    false,
+                    true,
+                    &favorite_ids.tracks,
+                );
             }
             Popup::Artist(artist) => {
                 let visible_rows = (artist.current_row_count() + 1).min(15) as u16;
@@ -328,12 +332,19 @@ impl Popup {
 
                 if let Some(state) = artist.current_state_mut() {
                     match state {
-                        SelectedArtistPopupSubtabMut::Albums(album_list) => {
-                            album_list.render(chunks[1], frame.buffer_mut(), true)
-                        }
-                        SelectedArtistPopupSubtabMut::TopTracks(track_list) => {
-                            track_list.render(chunks[1], frame.buffer_mut(), true, true)
-                        }
+                        SelectedArtistPopupSubtabMut::Albums(album_list) => album_list.render(
+                            chunks[1],
+                            frame.buffer_mut(),
+                            true,
+                            &favorite_ids.albums,
+                        ),
+                        SelectedArtistPopupSubtabMut::TopTracks(track_list) => track_list.render(
+                            chunks[1],
+                            frame.buffer_mut(),
+                            true,
+                            true,
+                            &favorite_ids.tracks,
+                        ),
                     }
                 }
             }
@@ -371,9 +382,13 @@ impl Popup {
                     ])
                     .split(inner);
 
-                playlist_state
-                    .tracks
-                    .render(chunks[0], frame.buffer_mut(), true, true);
+                playlist_state.tracks.render(
+                    chunks[0],
+                    frame.buffer_mut(),
+                    true,
+                    true,
+                    &favorite_ids.tracks,
+                );
                 frame.render_widget(buttons, chunks[2]);
             }
             Popup::Track(track_state) => {

--- a/qobuz-player-tui/src/queue.rs
+++ b/qobuz-player-tui/src/queue.rs
@@ -15,7 +15,7 @@ use ratatui::{
 };
 
 use crate::{
-    app::{NotificationList, Output},
+    app::{FavoriteAdd, FavoriteRemove, NotificationList, Output},
     ui::{basic_list_table, block, mark_explicit_and_hifi, mark_favorite},
 };
 
@@ -145,7 +145,7 @@ impl QueueState {
                                 "{} added to favorites",
                                 selected.title
                             )));
-                            return Ok(Output::UpdateFavorites);
+                            return Ok(Output::FavoriteAdded(FavoriteAdd::Track(selected.clone())));
                         }
                         Ok(Output::Consumed)
                     }
@@ -161,7 +161,7 @@ impl QueueState {
                                 "{} removed from favorites",
                                 selected.title
                             )));
-                            return Ok(Output::UpdateFavorites);
+                            return Ok(Output::FavoriteRemoved(FavoriteRemove::Track(selected.id)));
                         }
                         Ok(Output::Consumed)
                     }

--- a/qobuz-player-tui/src/queue.rs
+++ b/qobuz-player-tui/src/queue.rs
@@ -1,6 +1,11 @@
+use std::collections::HashSet;
+
 use qobuz_player_controls::{
+    AppResult,
+    client::Client,
     controls::Controls,
     models::{Track, TrackStatus},
+    notification::Notification,
 };
 use ratatui::{
     crossterm::event::{Event, KeyCode, KeyEventKind},
@@ -10,8 +15,8 @@ use ratatui::{
 };
 
 use crate::{
-    app::Output,
-    ui::{basic_list_table, block, mark_explicit_and_hifi},
+    app::{NotificationList, Output},
+    ui::{basic_list_table, block, mark_explicit_and_hifi, mark_favorite},
 };
 
 pub struct QueueState {
@@ -26,7 +31,7 @@ impl QueueState {
             state: Default::default(),
         }
     }
-    pub fn render(&mut self, frame: &mut Frame, area: Rect) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, favorite_tracks: &HashSet<u32>) {
         let table = basic_list_table(
             self.items
                 .iter()
@@ -40,18 +45,20 @@ impl QueueState {
                             Style::default().add_modifier(Modifier::CROSSED_OUT)
                         }
                     };
-                    Row::new(Line::from(vec![
-                        format!(
-                            "{} {}",
-                            index + 1,
-                            mark_explicit_and_hifi(
-                                track.title.clone(),
-                                track.explicit,
-                                track.hires_available
-                            )
-                        )
-                        .set_style(style),
-                    ]))
+
+                    let title = mark_favorite(
+                        mark_explicit_and_hifi(
+                            track.title.clone(),
+                            track.explicit,
+                            track.hires_available,
+                        ),
+                        favorite_tracks.contains(&track.id),
+                    );
+
+                    let mut spans = vec![Span::from(format!("{} ", index + 1))];
+                    spans.extend(title.spans);
+
+                    Row::new(vec![Line::from(spans).set_style(style)])
                 })
                 .collect(),
             true,
@@ -69,24 +76,30 @@ impl QueueState {
         self.items = items
     }
 
-    pub async fn handle_events(&mut self, event: Event, controls: &Controls) -> Output {
+    pub async fn handle_events(
+        &mut self,
+        event: Event,
+        client: &Client,
+        controls: &Controls,
+        notifications: &mut NotificationList,
+    ) -> AppResult<Output> {
         match event {
             Event::Key(key_event) if key_event.kind == KeyEventKind::Press => {
                 match key_event.code {
                     KeyCode::Down | KeyCode::Char('j') => {
                         self.state.select_next();
-                        Output::Consumed
+                        Ok(Output::Consumed)
                     }
                     KeyCode::Up | KeyCode::Char('k') => {
                         self.state.select_previous();
-                        Output::Consumed
+                        Ok(Output::Consumed)
                     }
                     KeyCode::Char('d') => {
                         let index = self.state.selected();
 
                         if let Some(index) = index {
                             if index == self.items().len() - 1 {
-                                return Output::Consumed;
+                                return Ok(Output::Consumed);
                             }
 
                             let mut order: Vec<_> =
@@ -95,14 +108,14 @@ impl QueueState {
                             order.swap(index, index + 1);
                             controls.reorder_queue(order);
                         }
-                        Output::Consumed
+                        Ok(Output::Consumed)
                     }
                     KeyCode::Char('u') => {
                         let index = self.state.selected();
 
                         if let Some(index) = index {
                             if index == 0 {
-                                return Output::Consumed;
+                                return Ok(Output::Consumed);
                             }
                             let mut order: Vec<_> =
                                 self.items().iter().enumerate().map(|x| x.0).collect();
@@ -110,7 +123,7 @@ impl QueueState {
                             order.swap(index, index - 1);
                             controls.reorder_queue(order);
                         }
-                        Output::Consumed
+                        Ok(Output::Consumed)
                     }
                     KeyCode::Char('D') => {
                         let index = self.state.selected();
@@ -118,7 +131,39 @@ impl QueueState {
                         if let Some(index) = index {
                             controls.remove_index_from_queue(index);
                         }
-                        Output::Consumed
+                        Ok(Output::Consumed)
+                    }
+                    KeyCode::Char('A') => {
+                        let selected = self
+                            .state
+                            .selected()
+                            .and_then(|index| self.items.get(index));
+
+                        if let Some(selected) = selected {
+                            client.add_favorite_track(selected.id).await?;
+                            notifications.push(Notification::Info(format!(
+                                "{} added to favorites",
+                                selected.title
+                            )));
+                            return Ok(Output::UpdateFavorites);
+                        }
+                        Ok(Output::Consumed)
+                    }
+                    KeyCode::Char('U') => {
+                        let selected = self
+                            .state
+                            .selected()
+                            .and_then(|index| self.items.get(index));
+
+                        if let Some(selected) = selected {
+                            client.remove_favorite_track(selected.id).await?;
+                            notifications.push(Notification::Info(format!(
+                                "{} removed from favorites",
+                                selected.title
+                            )));
+                            return Ok(Output::UpdateFavorites);
+                        }
+                        Ok(Output::Consumed)
                     }
                     KeyCode::Enter => {
                         let index = self.state.selected();
@@ -126,13 +171,13 @@ impl QueueState {
                         if let Some(index) = index {
                             controls.skip_to_position(index, true);
                         }
-                        Output::Consumed
+                        Ok(Output::Consumed)
                     }
 
-                    _ => Output::NotConsumed,
+                    _ => Ok(Output::NotConsumed),
                 }
             }
-            _ => Output::NotConsumed,
+            _ => Ok(Output::NotConsumed),
         }
     }
 }

--- a/qobuz-player-tui/src/search.rs
+++ b/qobuz-player-tui/src/search.rs
@@ -7,7 +7,7 @@ use ratatui::{
 use tui_input::{Input, backend::crossterm::EventHandler};
 
 use crate::{
-    app::{NotificationList, Output},
+    app::{FavoriteIds, NotificationList, Output},
     sub_tab::SubTab,
     ui::{block, render_input, sidebar},
     widgets::{
@@ -38,7 +38,7 @@ pub struct SearchState {
 }
 
 impl SearchState {
-    pub fn render(&mut self, frame: &mut Frame, area: Rect) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, favorite_ids: &FavoriteIds) {
         let tab_content_area_split = Layout::default()
             .constraints([Constraint::Length(3), Constraint::Min(1)])
             .split(area);
@@ -72,20 +72,29 @@ impl SearchState {
         let content_focused = self.focus == SearchFocus::Content;
 
         match self.sub_tab {
-            SubTab::Albums => self
-                .albums
-                .render(chunks[1], frame.buffer_mut(), content_focused),
-            SubTab::Artists => self
-                .artists
-                .render(chunks[1], frame.buffer_mut(), content_focused),
+            SubTab::Albums => self.albums.render(
+                chunks[1],
+                frame.buffer_mut(),
+                content_focused,
+                &favorite_ids.albums,
+            ),
+            SubTab::Artists => self.artists.render(
+                chunks[1],
+                frame.buffer_mut(),
+                content_focused,
+                &favorite_ids.artists,
+            ),
             SubTab::Playlists => {
                 self.playlists
                     .render(chunks[1], frame.buffer_mut(), content_focused)
             }
-            SubTab::Tracks => {
-                self.tracks
-                    .render(chunks[1], frame.buffer_mut(), true, content_focused)
-            }
+            SubTab::Tracks => self.tracks.render(
+                chunks[1],
+                frame.buffer_mut(),
+                true,
+                content_focused,
+                &favorite_ids.tracks,
+            ),
         };
     }
 

--- a/qobuz-player-tui/src/ui.rs
+++ b/qobuz-player-tui/src/ui.rs
@@ -87,18 +87,19 @@ impl App {
             chunks[1].union(chunks[2])
         };
 
+        let favorite_ids = &self.favorite_ids;
         match self.current_screen {
-            Tab::Favorites => self.favorites.render(frame, tab_content_area),
-            Tab::Search => self.search.render(frame, tab_content_area),
+            Tab::Favorites => self.favorites.render(frame, tab_content_area, favorite_ids),
+            Tab::Search => self.search.render(frame, tab_content_area, favorite_ids),
             Tab::Queue => self.queue.render(frame, tab_content_area),
-            Tab::Discover => self.discover.render(frame, tab_content_area),
-            Tab::Genres => self.genres.render(frame, tab_content_area),
+            Tab::Discover => self.discover.render(frame, tab_content_area, favorite_ids),
+            Tab::Genres => self.genres.render(frame, tab_content_area, favorite_ids),
             Tab::Preferences => self.preferences.render(frame, tab_content_area),
         }
 
         if let AppState::Popup(popups) = &mut self.app_state {
             for popup in popups {
-                popup.render(frame);
+                popup.render(frame, &self.favorite_ids);
             }
         }
     }
@@ -346,6 +347,20 @@ pub fn mark_explicit_and_hifi(
     }
 
     Line::from(parts)
+}
+
+pub fn mark_favorite(line: Line<'static>, is_favorite: bool) -> Line<'static> {
+    if !is_favorite {
+        return line;
+    }
+
+    let mut spans = line.spans;
+    spans.push(Span::raw(" "));
+    spans.push(Span::styled(
+        "\u{f004}",
+        Style::default().add_modifier(Modifier::DIM),
+    ));
+    Line::from(spans)
 }
 
 pub fn mark_as_owned(title: String, owned: bool) -> Line<'static> {

--- a/qobuz-player-tui/src/ui.rs
+++ b/qobuz-player-tui/src/ui.rs
@@ -91,7 +91,9 @@ impl App {
         match self.current_screen {
             Tab::Favorites => self.favorites.render(frame, tab_content_area, favorite_ids),
             Tab::Search => self.search.render(frame, tab_content_area, favorite_ids),
-            Tab::Queue => self.queue.render(frame, tab_content_area),
+            Tab::Queue => self
+                .queue
+                .render(frame, tab_content_area, &favorite_ids.tracks),
             Tab::Discover => self.discover.render(frame, tab_content_area, favorite_ids),
             Tab::Genres => self.genres.render(frame, tab_content_area, favorite_ids),
             Tab::Preferences => self.preferences.render(frame, tab_content_area),

--- a/qobuz-player-tui/src/widgets/album_list.rs
+++ b/qobuz-player-tui/src/widgets/album_list.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use qobuz_player_controls::{
     AppResult, client::Client, controls::Controls, models::AlbumSimple, notification::Notification,
 };
@@ -15,7 +17,7 @@ use crate::{
     popup::{AlbumPopupState, Popup},
     ui::{
         COLUMN_SPACING, HIGHLIGHT_STYLE, SELECTED_STYLE, fetch_image, format_duration,
-        mark_explicit_and_hifi,
+        mark_explicit_and_hifi, mark_favorite,
     },
 };
 
@@ -36,8 +38,14 @@ impl AlbumList {
         Self { items: albums }
     }
 
-    pub fn render(&mut self, area: Rect, buf: &mut Buffer, focus: bool) {
-        let table = album_table(self.items.filter(), focus);
+    pub fn render(
+        &mut self,
+        area: Rect,
+        buf: &mut Buffer,
+        focus: bool,
+        favorite_albums: &HashSet<String>,
+    ) {
+        let table = album_table(self.items.filter(), focus, favorite_albums);
         table.render(area, buf, &mut self.items.state);
     }
 
@@ -182,12 +190,18 @@ impl AlbumList {
     }
 }
 
-pub fn album_table<'a>(rows: &[AlbumSimple], focus: bool) -> Table<'a> {
+pub fn album_table<'a>(
+    rows: &[AlbumSimple],
+    focus: bool,
+    favorite_albums: &HashSet<String>,
+) -> Table<'a> {
     let body_rows: Vec<Row<'a>> = rows
         .iter()
         .map(|album| {
+            let title =
+                mark_explicit_and_hifi(album.title.clone(), album.explicit, album.hires_available);
             Row::new(vec![
-                mark_explicit_and_hifi(album.title.clone(), album.explicit, album.hires_available),
+                mark_favorite(title, favorite_albums.contains(&album.id)),
                 Line::from(album.artist.name.clone()),
                 Line::from(album.release_year.to_string()),
                 Line::from(format_duration(album.duration_seconds)),

--- a/qobuz-player-tui/src/widgets/album_list.rs
+++ b/qobuz-player-tui/src/widgets/album_list.rs
@@ -13,7 +13,7 @@ use ratatui::{
 };
 
 use crate::{
-    app::{FilteredListState, NotificationList, Output},
+    app::{FavoriteAdd, FavoriteRemove, FilteredListState, NotificationList, Output},
     popup::{AlbumPopupState, Popup},
     ui::{
         COLUMN_SPACING, HIGHLIGHT_STYLE, SELECTED_STYLE, fetch_image, format_duration,
@@ -93,7 +93,7 @@ impl AlbumList {
                         "{} added to favorites",
                         selected.title
                     )));
-                    return Ok(Output::UpdateFavorites);
+                    return Ok(Output::FavoriteAdded(FavoriteAdd::Album(selected.clone())));
                 }
 
                 Ok(Output::Consumed)
@@ -110,7 +110,9 @@ impl AlbumList {
                         "{} removed from favorites",
                         selected.title
                     )));
-                    return Ok(Output::UpdateFavorites);
+                    return Ok(Output::FavoriteRemoved(FavoriteRemove::Album(
+                        selected.id.clone(),
+                    )));
                 }
 
                 Ok(Output::Consumed)

--- a/qobuz-player-tui/src/widgets/artist_list.rs
+++ b/qobuz-player-tui/src/widgets/artist_list.rs
@@ -48,7 +48,10 @@ impl ArtistList {
                 .iter()
                 .map(|artist| {
                     let name = Line::from(artist.name.clone());
-                    Row::new(mark_favorite(name, favorite_artists.contains(&artist.id)))
+                    Row::new(vec![mark_favorite(
+                        name,
+                        favorite_artists.contains(&artist.id),
+                    )])
                 })
                 .collect::<Vec<_>>(),
             focus,

--- a/qobuz-player-tui/src/widgets/artist_list.rs
+++ b/qobuz-player-tui/src/widgets/artist_list.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use qobuz_player_controls::{
     AppResult, client::Client, models::Artist, notification::Notification,
 };
@@ -12,7 +14,7 @@ use ratatui::{
 use crate::{
     app::{FilteredListState, NotificationList, Output},
     popup::{ArtistPopupState, Popup},
-    ui::{basic_list_table, fetch_image},
+    ui::{basic_list_table, fetch_image, mark_favorite},
 };
 
 #[derive(Default)]
@@ -33,12 +35,21 @@ impl ArtistList {
         Self { items: artists }
     }
 
-    pub fn render(&mut self, area: Rect, buf: &mut Buffer, focus: bool) {
+    pub fn render(
+        &mut self,
+        area: Rect,
+        buf: &mut Buffer,
+        focus: bool,
+        favorite_artists: &HashSet<u32>,
+    ) {
         let table = basic_list_table(
             self.items
                 .filter()
                 .iter()
-                .map(|artist| Row::new(Line::from(artist.name.clone())))
+                .map(|artist| {
+                    let name = Line::from(artist.name.clone());
+                    Row::new(mark_favorite(name, favorite_artists.contains(&artist.id)))
+                })
                 .collect::<Vec<_>>(),
             focus,
         );

--- a/qobuz-player-tui/src/widgets/artist_list.rs
+++ b/qobuz-player-tui/src/widgets/artist_list.rs
@@ -12,7 +12,7 @@ use ratatui::{
 };
 
 use crate::{
-    app::{FilteredListState, NotificationList, Output},
+    app::{FavoriteAdd, FavoriteRemove, FilteredListState, NotificationList, Output},
     popup::{ArtistPopupState, Popup},
     ui::{basic_list_table, fetch_image, mark_favorite},
 };
@@ -100,9 +100,9 @@ impl ArtistList {
                         "{} added to favorites",
                         selected.name
                     )));
-                    return Ok(Output::UpdateFavorites);
+                    return Ok(Output::FavoriteAdded(FavoriteAdd::Artist(selected.clone())));
                 }
-                Ok(Output::UpdateFavorites)
+                Ok(Output::Consumed)
             }
 
             KeyCode::Char('U') => {
@@ -116,9 +116,9 @@ impl ArtistList {
                         "{} removed from favorites",
                         selected.name
                     )));
-                    return Ok(Output::UpdateFavorites);
+                    return Ok(Output::FavoriteRemoved(FavoriteRemove::Artist(selected.id)));
                 }
-                Ok(Output::UpdateFavorites)
+                Ok(Output::Consumed)
             }
 
             KeyCode::Char('i') => {

--- a/qobuz-player-tui/src/widgets/track_list.rs
+++ b/qobuz-player-tui/src/widgets/track_list.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use qobuz_player_controls::{
     AppResult, client::Client, controls::Controls, models::Track, notification::Notification,
 };
@@ -15,7 +17,7 @@ use crate::{
     popup::Popup,
     ui::{
         COLUMN_SPACING, HIGHLIGHT_STYLE, SELECTED_STYLE, fetch_image, format_duration,
-        mark_explicit_and_hifi,
+        mark_explicit_and_hifi, mark_favorite,
     },
 };
 
@@ -44,8 +46,15 @@ impl TrackList {
         Self { items: tracks }
     }
 
-    pub fn render(&mut self, area: Rect, buf: &mut Buffer, show_album: bool, focus: bool) {
-        let table = track_table(self.items.filter(), show_album, focus);
+    pub fn render(
+        &mut self,
+        area: Rect,
+        buf: &mut Buffer,
+        show_album: bool,
+        focus: bool,
+        favorite_tracks: &HashSet<u32>,
+    ) {
+        let table = track_table(self.items.filter(), show_album, focus, favorite_tracks);
         table.render(area, buf, &mut self.items.state);
     }
 
@@ -219,17 +228,20 @@ impl TrackList {
     }
 }
 
-fn track_table<'a>(rows: &[Track], show_album: bool, focus: bool) -> Table<'a> {
+fn track_table<'a>(
+    rows: &[Track],
+    show_album: bool,
+    focus: bool,
+    favorite_tracks: &HashSet<u32>,
+) -> Table<'a> {
     let body_rows: Vec<Row<'a>> = rows
         .iter()
         .map(|track| {
             let mut cols: Vec<Line<'a>> = Vec::with_capacity(if show_album { 4 } else { 3 });
 
-            cols.push(mark_explicit_and_hifi(
-                track.title.clone(),
-                track.explicit,
-                track.hires_available,
-            ));
+            let title =
+                mark_explicit_and_hifi(track.title.clone(), track.explicit, track.hires_available);
+            cols.push(mark_favorite(title, favorite_tracks.contains(&track.id)));
 
             cols.push(Line::from(track.artist_name.clone().unwrap_or_default()));
 

--- a/qobuz-player-tui/src/widgets/track_list.rs
+++ b/qobuz-player-tui/src/widgets/track_list.rs
@@ -13,7 +13,7 @@ use ratatui::{
 };
 
 use crate::{
-    app::{FilteredListState, NotificationList, Output},
+    app::{FavoriteAdd, FavoriteRemove, FilteredListState, NotificationList, Output},
     popup::Popup,
     ui::{
         COLUMN_SPACING, HIGHLIGHT_STYLE, SELECTED_STYLE, fetch_image, format_duration,
@@ -156,7 +156,7 @@ impl TrackList {
                         "{} added to favorites",
                         selected.title
                     )));
-                    return Ok(Output::UpdateFavorites);
+                    return Ok(Output::FavoriteAdded(FavoriteAdd::Track(selected.clone())));
                 }
 
                 Ok(Output::Consumed)
@@ -172,7 +172,7 @@ impl TrackList {
                         "{} removed from favorites",
                         selected.title
                     )));
-                    return Ok(Output::UpdateFavorites);
+                    return Ok(Output::FavoriteRemoved(FavoriteRemove::Track(selected.id)));
                 }
                 Ok(Output::Consumed)
             }


### PR DESCRIPTION
Hello hello,

First of, congrats for the improvements on the TUI! I had been using my outdated fork build for quite some time, and missed out on the sidebar, settings, ...

This PR does the following:

* add a heart indicator for favorite tracks
* sort by most recent fav tracks instead of alphabetically, for consistency with official player
* auto add the next tracks in queue when playing back a fav track, to mimic the official clients again