### PR TITLE
Add mqtt

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -78,11 +78,17 @@ jobs:
         run: |
           sudo apt-get update
 
-      - name: Install dependencies
+      - name: Install ubuntu dependencies
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config libasound2-dev
+
+      - name: Install windows dependencies
+        if: startsWith(matrix.os, 'windows')
+        shell: powershell
+        run: |
+          vcpkg install openssl
 
       - name: Test 
         run: cargo test --workspace --exclude qobuz-player-client --exclude qobuz-player-gtk
@@ -90,6 +96,9 @@ jobs:
       - name: Build gpio 
         if: startsWith(matrix.os, 'ubuntu')
         run: cargo build --workspace --features gpio --exclude qobuz-player-gtk
+
+      - name: Build mqtt
+        run: cargo build --workspace --features mqtt --exclude qobuz-player-gtk
 
   build-flatpak:
     name: "Flatpak ${{ matrix.variant.arch }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4203,9 +4203,11 @@ dependencies = [
  "qobuz-player-cli",
  "qobuz-player-controls",
  "qobuz-player-gpio",
+ "qobuz-player-mqtt",
  "qonductor",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,6 +1882,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3705,6 +3711,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
+name = "paho-mqtt"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c6e899549be260b8c8d7fb6908d72eacb9a1e10229c7e294a7a8ff1c768620"
+dependencies = [
+ "async-channel",
+ "crossbeam-channel",
+ "futures",
+ "futures-timer",
+ "libc",
+ "log",
+ "paho-mqtt-sys",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "paho-mqtt-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00e508bdadfa0d58d67792060fa447ec20729db5dc76e3dc7de9f4d29e521a43"
+dependencies = [
+ "cmake",
+ "openssl-sys",
+]
+
+[[package]]
 name = "palette"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4236,6 +4268,19 @@ dependencies = [
  "mpris-server",
  "qobuz-player-controls",
  "tokio",
+]
+
+[[package]]
+name = "qobuz-player-mqtt"
+version = "1.0.0"
+dependencies = [
+ "clap",
+ "paho-mqtt",
+ "qobuz-player-controls",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "qobuz-player-connect",
   "qobuz-player-cli",
   "qobuz-player-gtk",
+  "qobuz-player-mqtt"
 ]
 resolver = "2"
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779357205,
+        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,28 @@
+{
+  description = "Qobine config";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = import nixpkgs { inherit system; };
+      in with pkgs;
+      {
+        devShell = mkShell {
+          nativeBuildInputs = [ pkg-config sqlx-cli just ];
+          buildInputs = [
+            # qobuz-player + qobuz-player-connect + qobuz-player-rfid + qobuz-player-web (base libs)
+            alsa-lib
+            openssl
+            # qobuz-player-gtk (+ base libs)
+            libadwaita
+            webkitgtk_6_0
+          ];
+          ALSA_PLUGIN_DIR="${pipewire}/lib/alsa-lib";
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,13 @@
       in with pkgs;
       {
         devShell = mkShell {
-          nativeBuildInputs = [ pkg-config sqlx-cli just ];
+          nativeBuildInputs = [ 
+            pkg-config 
+            sqlx-cli 
+            just
+            # --feature mqtt
+            cmake
+          ];
           buildInputs = [
             # qobuz-player + qobuz-player-connect + qobuz-player-rfid + qobuz-player-web (base libs)
             alsa-lib

--- a/qobuz-player-connect/Cargo.toml
+++ b/qobuz-player-connect/Cargo.toml
@@ -12,11 +12,13 @@ path = "src/main.rs"
 
 [features]
 gpio = ["qobuz-player-gpio/gpio"]
+mqtt = ["dep:qobuz-player-mqtt"]
 
 [dependencies]
 qobuz-player-controls = { version = "*", path = "../qobuz-player-controls" }
 qobuz-player-gpio = { version = "*", path = "../qobuz-player-gpio", optional = true }
 qobuz-player-cli = { version = "*", path = "../qobuz-player-cli" }
+qobuz-player-mqtt = { version = "*", path = "../qobuz-player-mqtt", optional = true, features = ["cli"]}
 
 qonductor.workspace = true
 tokio.workspace = true
@@ -24,3 +26,4 @@ tracing.workspace = true
 
 # binary dependencies
 clap.workspace = true
+tracing-subscriber.workspace = true

--- a/qobuz-player-connect/src/main.rs
+++ b/qobuz-player-connect/src/main.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "gpio")]
-use qobuz_player_cli::GpioArgs;
 use qobuz_player_cli::{
     ConnectNameArgs, DelayArgs, SharedArgs, SharedCommands, create_player, default_audio_cache,
     default_audio_quality, get_client, handle_shared_commands, spawn_clean_up,
@@ -8,9 +6,7 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 
 use clap::Parser;
-use qobuz_player_controls::{
-    AppResult, database::Database, error::Error, notification::NotificationBroadcast,
-};
+use qobuz_player_controls::{AppResult, database::Database, notification::NotificationBroadcast};
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
@@ -26,7 +22,11 @@ struct Arguments {
 
     #[cfg(feature = "gpio")]
     #[clap(flatten)]
-    gpio: GpioArgs,
+    gpio: qobuz_player_cli::GpioArgs,
+
+    #[cfg(feature = "mqtt")]
+    #[clap(flatten)]
+    mqtt_config: qobuz_player_mqtt::MqttConfig,
 
     #[clap(subcommand)]
     command: Option<SharedCommands>,
@@ -43,6 +43,8 @@ async fn main() {
 }
 
 pub async fn run() -> AppResult<()> {
+    tracing_subscriber::fmt::init();
+
     let args = Arguments::parse();
     let database = Arc::new(Database::new().await?);
     let headless = true;
@@ -83,7 +85,28 @@ pub async fn run() -> AppResult<()> {
         let status_receiver = player.status();
         tokio::spawn(async move {
             if let Err(e) = qobuz_player_gpio::init(status_receiver).await {
-                error_exit(e.into());
+                error_exit(e);
+            }
+        });
+    }
+
+    #[cfg(feature = "mqtt")]
+    {
+        let controls = player.controls();
+        let status_receiver = player.status();
+        let volume_reciever = player.volume();
+        let track_list_reciever = player.tracklist();
+        tokio::spawn(async move {
+            if let Err(e) = qobuz_player_mqtt::init(
+                controls,
+                status_receiver,
+                volume_reciever,
+                track_list_reciever,
+                args.mqtt_config,
+            )
+            .await
+            {
+                error_exit(e);
             }
         });
     }
@@ -121,7 +144,7 @@ pub async fn run() -> AppResult<()> {
     Ok(())
 }
 
-fn error_exit(error: Error) {
+fn error_exit(error: impl std::error::Error) {
     eprintln!("{error}");
     std::process::exit(1);
 }

--- a/qobuz-player-mqtt/Cargo.toml
+++ b/qobuz-player-mqtt/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "qobuz-player-mqtt"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+repository.workspace = true
+
+[features]
+cli = ["dep:clap"]
+
+[dependencies]
+qobuz-player-controls = { version = "*", path = "../qobuz-player-controls" }
+
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+clap = { workspace = true, optional = true }
+
+paho-mqtt = "0.14.0"

--- a/qobuz-player-mqtt/src/lib.rs
+++ b/qobuz-player-mqtt/src/lib.rs
@@ -1,0 +1,161 @@
+use std::time::Duration;
+
+use paho_mqtt as mqtt;
+
+use qobuz_player_controls::{
+    AppResult, StatusReceiver, TracklistReceiver, VolumeReceiver, controls::Controls,
+};
+use tracing::{error, info, warn};
+
+const QOS: i32 = 0;
+
+#[cfg(feature = "cli")]
+fn check_server_uri(uri: &str) -> Result<String, String> {
+    if let Some((protocol, host_port)) = uri.trim().split_once("://")
+        && ["ssl", "tcp"].contains(&protocol)
+        && let Some((host, port)) = host_port.split_once(":")
+        && port.chars().all(char::is_numeric)
+    {
+        return Ok(format!("{protocol}://{host}:{port}"));
+    }
+    Err("Not a valid uri".into())
+}
+
+#[cfg_attr(feature = "cli", derive(clap::Args))]
+pub struct MqttConfig {
+    /// Sets the the URI to the MQTT broker.
+    ///
+    /// Expects a string in the form {tcp|ssl}://{host}:{port},
+    /// where host can be an IP address or domain name.
+    #[cfg_attr(feature = "cli", clap(long, value_parser = check_server_uri))]
+    mqtt_server_uri: String,
+    /// Sets the user name for authentication with the broker.
+    #[cfg_attr(feature = "cli", clap(long, requires("mqtt_password")))]
+    mqtt_user_name: Option<String>,
+    /// Sets the password for authentication with the broker. This works with the user name.
+    #[cfg_attr(feature = "cli", clap(long, requires("mqtt_user_name")))]
+    mqtt_password: Option<String>,
+    /// Sets the client identifier string
+    /// that is sent to the server.
+    ///
+    /// The client ID is a unique name to
+    /// identify the client to the server,
+    /// which can be used if the client
+    /// desires the server to hold state
+    /// about the session.
+    ///
+    /// If the client
+    /// requests a clean session, this
+    /// can be an empty string, in which
+    /// case the server will assign a
+    /// random name for the client.
+    #[cfg_attr(feature = "cli", clap(long, default_value = ""))]
+    mqtt_client_id: String,
+    /// Sets the mqtt topic.
+    ///
+    /// Will publish in {topic}/pub and recieve messages from {topic}/sub.
+    #[cfg_attr(feature = "cli", clap(long, default_value = "qobine"))]
+    mqtt_topic: String,
+}
+
+fn prepared_message<V: Into<Vec<u8>>>(topic: &str, payload: V) -> mqtt::Message {
+    mqtt::Message::new(format!("{}/pub", topic), payload, QOS)
+}
+
+fn publish_serializible<T: serde::Serialize>(
+    mqtt_client: &mqtt::AsyncClient,
+    topic: &str,
+    serializible: &T,
+) {
+    match serde_json::to_string(serializible) {
+        Ok(json) => mqtt_client
+            .publish(prepared_message(topic, json))
+            .wait()
+            .unwrap_or_else(|e| error!("Could not publish message: {e}")),
+        Err(e) => error!("Tracklist could not be serialized to json: {e}"),
+    }
+}
+
+pub async fn init(
+    controls: Controls,
+    mut status_receiver: StatusReceiver,
+    mut volume_receiver: VolumeReceiver,
+    mut track_list_receiver: TracklistReceiver,
+    args: MqttConfig,
+) -> AppResult<(), mqtt::Error> {
+    let mqtt_create_opts = mqtt::CreateOptionsBuilder::new()
+        .server_uri(args.mqtt_server_uri)
+        .allow_disconnected_send_at_anytime(true)
+        .send_while_disconnected(true)
+        .max_buffered_messages(10)
+        .delete_oldest_messages(true)
+        .client_id(args.mqtt_client_id)
+        .finalize();
+
+    let topic = args.mqtt_topic.clone();
+    let mut mqtt_client = mqtt::AsyncClient::new(mqtt_create_opts)?;
+    mqtt_client.set_connected_callback(move |mqtt_client| {
+        _ = mqtt_client.subscribe(format!("{}/sub", topic), QOS).wait();
+    });
+
+    let subscribe_stream = mqtt_client.get_stream(1);
+
+    let mqtt_connect_opts = {
+        let mut connect_options_builder = mqtt::ConnectOptionsBuilder::new();
+        connect_options_builder
+            .keep_alive_interval(Duration::from_secs(20))
+            .automatic_reconnect(Duration::from_millis(1), Duration::from_secs(24 * 60 * 60))
+            .clean_session(true);
+        if let Some(user_name) = args.mqtt_user_name
+            && let Some(password) = args.mqtt_password
+        {
+            connect_options_builder
+                .user_name(user_name)
+                .password(password);
+        }
+        connect_options_builder.finalize()
+    };
+
+    mqtt_client.connect(mqtt_connect_opts).wait()?;
+
+    loop {
+        tokio::select! {
+            Ok(()) = status_receiver.changed(), if mqtt_client.is_connected() => {
+                publish_serializible(&mqtt_client, &args.mqtt_topic, &*status_receiver.borrow_and_update());
+            },
+            Ok(()) = volume_receiver.changed(), if mqtt_client.is_connected() => {
+                let volume = *volume_receiver.borrow_and_update();
+                let volume = serde_json::json!({"volume": volume}).to_string();
+                mqtt_client.publish(prepared_message(&args.mqtt_topic, volume));
+            }
+            Ok(()) = track_list_receiver.changed(), if mqtt_client.is_connected() => {
+                publish_serializible(&mqtt_client, &args.mqtt_topic, &*track_list_receiver.borrow_and_update());
+            }
+            Ok(Some(message)) = subscribe_stream.recv() => {
+                match message.payload_str().as_ref() {
+                    "play" => controls.play(),
+                    "pause" => controls.pause(),
+                    "playpause" => controls.play_pause(),
+                    "jumpbackward" => controls.jump_forward(),
+                    "jumpforward" => controls.jump_forward(),
+                    "next" => controls.next(),
+                    "previous" => controls.previous(),
+                    // TODO: volumeup, volumedown
+                    unrecognized_command => warn!("Unrecognized mqtt command: {unrecognized_command}")
+                }
+            }
+            else => {
+                if !mqtt_client.is_connected() {
+                    info!("Lost connection to mqtt.\n Reconnecting...");
+                    mqtt_client.reconnect().wait()?;
+                    info!("Reconnection Successfull.");
+
+                } else {
+                    info!("Player has stoped.\n Gracefully shutting down mqtt.");
+                    mqtt_client.disconnect(None).wait()?;
+                    return Ok(())
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hello!

Thank you for this project! 
I'm moving from Spotify to Qobuz and wanted to be able to play it throughout my house and I think this might be what I was looking for. One of the thing I also need is the ability to control the player through mqtt and thought it might be a nice addition to the project, thus the PR :star: 

I took a slightly different approach to the cli for the mqtt config, by including it in the lib itself (and conditionally compiling it if cli is needed) rather than placing it in the qobuz-player-cli. I feel it makes a bit more sense, as it prevents having to add any conditional compilation to the latter and all relevant code is nearby, even though the `cfg_attr` make it a bit more confusing. Let me know what you think~
Since I was also touching `main.rs` in qobuz-player-connect, I also changed the gpio arg to use the full path so as to have on less cfg to keep track of. Hope that makes sense.
Also added tracing_subscriber.

I also added a nix flake for a dev shell that includes the relevant libs (as well as sqlx-cli and just) needed to build the binaries.

I'm leaving this as draft as I haven't been able to fully test it since I don't have a payed account yet. Thought you might like to start going through it meanwhile though.