### PR TITLE
Re-use the picker across tracks

### DIFF
--- a/tui-module/src/app.rs
+++ b/tui-module/src/app.rs
@@ -26,7 +26,7 @@ use player_module::{
     notification::{Notification, NotificationBroadcast},
 };
 use ratatui::{DefaultTerminal, widgets::*};
-use ratatui_image::protocol::StatefulProtocol;
+use ratatui_image::{picker::Picker, protocol::StatefulProtocol};
 use std::{collections::HashSet, io, sync::Arc, time::Instant};
 use tokio::{
     sync::{mpsc, watch},
@@ -59,6 +59,7 @@ impl NotificationList {
 
 pub struct App {
     pub client: Arc<Client>,
+    pub picker: Picker,
     pub controls: Controls,
     pub database: Arc<Database>,
     pub position: PositionReceiver,
@@ -231,7 +232,7 @@ impl App {
         if let Some(image_url) = self.current_image_url.as_ref()
             && !self.disable_tui_album_cover
         {
-            let image = fetch_image(image_url).await;
+            let image = fetch_image(&self.picker, image_url).await;
             self.now_playing.image = image;
         };
 
@@ -266,8 +267,9 @@ impl App {
                     } else if !self.disable_tui_album_cover {
                         if let Some(url) = image_url.clone() {
                             let tx = image_tx.clone();
+                            let picker = self.picker.clone();
                             tokio::spawn(async move {
-                                let result = fetch_image(&url).await;
+                                let result = fetch_image(&picker, &url).await;
                                 let _ = tx.send(result).await;
                             });
                         }
@@ -406,6 +408,22 @@ impl App {
         self.favorites.filter.reset();
     }
 
+    async fn push_popup(&mut self, mut popup: Popup) {
+        if let Some(url) = popup.image_url() {
+            let image = fetch_image(&self.picker, &url).await;
+            popup.set_image(image);
+        }
+
+        let mut popups = match std::mem::take(&mut self.app_state) {
+            AppState::Popup(popups) => popups,
+            _ => Vec::new(),
+        };
+
+        popups.push(popup);
+        self.app_state = AppState::Popup(popups);
+        self.should_draw = true;
+    }
+
     async fn handle_output(&mut self, key_code: KeyCode, output: AppResult<Output>) {
         let output = match output {
             Ok(res) => res,
@@ -459,14 +477,7 @@ impl App {
                         && let Ok(album) = self.client.album(&album_id).await
                     {
                         let popup = Popup::Album(AlbumPopupState::new(album, &self.client).await);
-                        let mut popups = match std::mem::take(&mut self.app_state) {
-                            AppState::Popup(popups) => popups,
-                            _ => Vec::new(),
-                        };
-
-                        popups.push(popup);
-                        self.app_state = AppState::Popup(popups);
-                        self.should_draw = true;
+                        self.push_popup(popup).await;
                     }
                 }
                 KeyCode::Char('G') => {
@@ -480,14 +491,7 @@ impl App {
                         };
 
                         if let Ok(state) = ArtistPopupState::new(&artist, &self.client).await {
-                            let mut popups = match std::mem::take(&mut self.app_state) {
-                                AppState::Popup(popups) => popups,
-                                _ => Vec::new(),
-                            };
-
-                            popups.push(Popup::Artist(state));
-                            self.app_state = AppState::Popup(popups);
-                            self.should_draw = true;
+                            self.push_popup(Popup::Artist(state)).await;
                         }
                     }
                 }
@@ -495,19 +499,7 @@ impl App {
                     if let Some(id) = self.now_playing.playing_track.as_ref().map(|t| t.id)
                         && let Ok(track) = self.client.track(id).await
                     {
-                        let image = match track.image.as_ref() {
-                            Some(x) => fetch_image(x).await,
-                            None => None,
-                        };
-
-                        let mut popups = match std::mem::take(&mut self.app_state) {
-                            AppState::Popup(popups) => popups,
-                            _ => Vec::new(),
-                        };
-
-                        popups.push(Popup::TrackInfo(track, image, 0));
-                        self.app_state = AppState::Popup(popups);
-                        self.should_draw = true;
+                        self.push_popup(Popup::TrackInfo(track, None, 0)).await;
                     }
                 }
                 KeyCode::Char('q') => {
@@ -565,15 +557,7 @@ impl App {
                 _ => {}
             },
             Output::Popup(popup) => {
-                let mut popups = match std::mem::take(&mut self.app_state) {
-                    AppState::Popup(popups) => popups,
-                    _ => Vec::new(),
-                };
-
-                popups.push(popup);
-
-                self.app_state = AppState::Popup(popups);
-                self.should_draw = true;
+                self.push_popup(popup).await;
             }
             Output::PopPopupUpdateFavorites => {
                 if let AppState::Popup(popups) = &mut self.app_state {

--- a/tui-module/src/lib.rs
+++ b/tui-module/src/lib.rs
@@ -11,6 +11,7 @@ use player_module::{
 };
 use queue::QueueState;
 use ratatui::{prelude::*, widgets::*};
+use ratatui_image::picker::Picker;
 use tokio::sync::{mpsc, watch};
 use ui::center;
 
@@ -45,6 +46,8 @@ pub async fn init(
     disconnect_client_config_sender: watch::Sender<Option<DisconnectClientConfig>>,
 ) -> AppResult<()> {
     let mut terminal = ratatui::init();
+
+    let picker = Picker::from_query_stdio().unwrap_or_else(|_| Picker::halfblocks());
 
     draw_loading_screen(&mut terminal);
 
@@ -87,6 +90,7 @@ pub async fn init(
             initial_configuration,
         ),
         client,
+        picker,
         favorite_ids: Default::default(),
         connect_available_devices,
         connect_active_device,

--- a/tui-module/src/popup.rs
+++ b/tui-module/src/popup.rs
@@ -14,8 +14,8 @@ use tui_input::{Input, backend::crossterm::EventHandler};
 use crate::{
     app::{FavoriteIds, NotificationList, Output},
     ui::{
-        HIGHLIGHT_STYLE, block, center, centered_rect_fixed, fetch_image, format_seconds,
-        mark_favorite, render_input, tab_bar,
+        HIGHLIGHT_STYLE, block, center, centered_rect_fixed, format_seconds, mark_favorite,
+        render_input, tab_bar,
     },
     widgets::{
         album_list::AlbumList,
@@ -33,6 +33,7 @@ pub struct ArtistPopupState {
     compilations: AlbumList,
     similar: ArtistList,
     description: Option<String>,
+    image_url: Option<String>,
     image: Option<(StatefulProtocol, f32)>,
     selected_sub_tab: usize,
     top_tracks: TrackList,
@@ -66,11 +67,6 @@ impl ArtistPopupState {
         let id = artist.id;
         let artist_page = client.artist_page(id).await?;
 
-        let image = match artist_page.image {
-            Some(url) => fetch_image(&url).await,
-            None => None,
-        };
-
         let state = Self {
             artist_name: artist.name.clone(),
             albums: AlbumList::new(artist_page.albums),
@@ -79,7 +75,8 @@ impl ArtistPopupState {
             compilations: AlbumList::new(artist_page.compilations),
             similar: ArtistList::new(artist_page.similar_artists),
             description: artist_page.description,
-            image,
+            image_url: artist_page.image,
+            image: None,
             selected_sub_tab: 0,
             top_tracks: TrackList::new(artist_page.top_tracks),
             id: artist.id,
@@ -221,6 +218,7 @@ pub struct AlbumPopupState {
     tracks: TrackList,
     similar: AlbumList,
     description: Option<String>,
+    image_url: String,
     image: Option<(StatefulProtocol, f32)>,
     release_year: u32,
     total_tracks: u32,
@@ -248,7 +246,6 @@ enum SelectedAlbumPopupSubtabMut<'a> {
 
 impl AlbumPopupState {
     pub async fn new(album: Album, client: &Client) -> Self {
-        let image = fetch_image(&album.image).await;
         let similar = client.suggested_albums(&album.id).await.unwrap_or_default();
 
         Self {
@@ -257,7 +254,8 @@ impl AlbumPopupState {
             tracks: TrackList::new(album.tracks),
             similar: AlbumList::new(similar),
             description: album.description,
-            image,
+            image_url: album.image,
+            image: None,
             release_year: album.release_year,
             total_tracks: album.total_tracks,
             duration_seconds: album.duration_seconds,
@@ -469,6 +467,26 @@ pub enum Popup {
 }
 
 impl Popup {
+    pub fn image_url(&self) -> Option<String> {
+        match self {
+            Popup::Artist(state) => state.image_url.clone(),
+            Popup::Album(state) => Some(state.image_url.clone()),
+            Popup::PlaylistInfo(playlist, _) => playlist.image.clone(),
+            Popup::TrackInfo(track, _, _) => track.image.clone(),
+            _ => None,
+        }
+    }
+
+    pub fn set_image(&mut self, image: Option<(StatefulProtocol, f32)>) {
+        match self {
+            Popup::Artist(state) => state.image = image,
+            Popup::Album(state) => state.image = image,
+            Popup::PlaylistInfo(_, slot) => *slot = image,
+            Popup::TrackInfo(_, slot, _) => *slot = image,
+            _ => {}
+        }
+    }
+
     pub fn render(&mut self, frame: &mut Frame, favorite_ids: &FavoriteIds) {
         match self {
             Popup::Album(album) => {

--- a/tui-module/src/queue.rs
+++ b/tui-module/src/queue.rs
@@ -14,7 +14,7 @@ use ratatui::{
 use crate::{
     app::{FavoriteAdd, FavoriteRemove, NotificationList, Output},
     popup::Popup,
-    ui::{basic_list_table, block, fetch_image, mark_explicit_and_hifi, mark_favorite},
+    ui::{basic_list_table, block, mark_explicit_and_hifi, mark_favorite},
 };
 
 pub struct QueueState {
@@ -185,11 +185,7 @@ impl QueueState {
 
                         if let Some(id) = id {
                             let track = client.track(id).await?;
-                            let image = match track.image.as_ref() {
-                                Some(x) => fetch_image(x).await,
-                                None => None,
-                            };
-                            return Ok(Output::Popup(Popup::TrackInfo(track, image, 0)));
+                            return Ok(Output::Popup(Popup::TrackInfo(track, None, 0)));
                         }
                         Ok(Output::Consumed)
                     }

--- a/tui-module/src/ui.rs
+++ b/tui-module/src/ui.rs
@@ -472,15 +472,15 @@ pub fn format_seconds(seconds: u32) -> String {
     format!("{minutes:02}:{seconds:02}")
 }
 
-pub async fn fetch_image(image_url: &str) -> Option<(StatefulProtocol, f32)> {
+pub async fn fetch_image(picker: &Picker, image_url: &str) -> Option<(StatefulProtocol, f32)> {
     let client = reqwest::Client::new();
     let response = client.get(image_url).send().await.ok()?;
     let img_bytes = response.bytes().await.ok()?;
+    let picker = picker.clone();
 
     tokio::task::spawn_blocking(move || {
         let image = load_from_memory(&img_bytes).ok()?;
         let ratio = image.width() as f32 / image.height() as f32;
-        let picker = Picker::from_query_stdio().ok()?;
         Some((picker.new_resize_protocol(image), ratio))
     })
     .await

--- a/tui-module/src/widgets/playlist_list.rs
+++ b/tui-module/src/widgets/playlist_list.rs
@@ -12,10 +12,7 @@ use ratatui::{
 use crate::{
     app::{FilteredListState, NotificationList, Output},
     popup::{DeletePlaylistPopupState, NewPlaylistPopupState, PlaylistPopupState, Popup},
-    ui::{
-        COLUMN_SPACING, HIGHLIGHT_STYLE, SELECTED_STYLE, fetch_image, format_duration,
-        mark_as_owned,
-    },
+    ui::{COLUMN_SPACING, HIGHLIGHT_STYLE, SELECTED_STYLE, format_duration, mark_as_owned},
 };
 
 #[derive(Default)]
@@ -169,12 +166,7 @@ impl PlaylistList {
 
                 if let Some(id) = id {
                     let playlist = client.playlist(id).await?;
-                    let image = match playlist.image.as_ref() {
-                        Some(x) => fetch_image(x).await,
-                        None => None,
-                    };
-
-                    return Ok(Output::Popup(Popup::PlaylistInfo(playlist, image)));
+                    return Ok(Output::Popup(Popup::PlaylistInfo(playlist, None)));
                 }
                 Ok(Output::Consumed)
             }

--- a/tui-module/src/widgets/track_list.rs
+++ b/tui-module/src/widgets/track_list.rs
@@ -15,8 +15,8 @@ use crate::{
     app::{FavoriteAdd, FavoriteRemove, FilteredListState, NotificationList, Output},
     popup::Popup,
     ui::{
-        COLUMN_SPACING, HIGHLIGHT_STYLE, SELECTED_STYLE, fetch_image, format_duration,
-        mark_explicit_and_hifi, mark_favorite,
+        COLUMN_SPACING, HIGHLIGHT_STYLE, SELECTED_STYLE, format_duration, mark_explicit_and_hifi,
+        mark_favorite,
     },
 };
 
@@ -192,13 +192,7 @@ impl TrackList {
 
                 if let Some(id) = id {
                     let track = client.track(id).await?;
-
-                    let image = match track.image.as_ref() {
-                        Some(x) => fetch_image(x).await,
-                        None => None,
-                    };
-
-                    return Ok(Output::Popup(Popup::TrackInfo(track, image, 0)));
+                    return Ok(Output::Popup(Popup::TrackInfo(track, None, 0)));
                 }
                 Ok(Output::Consumed)
             }


### PR DESCRIPTION
I have been having UX issues on TUI since ... always. As they were minor I overlooked them, but the glitchiness bored me.
Basically I'm using ghostty, and the picker often failed to load the image in time (spent a solid 2/3s on it), while blocking any controller calls in the meantime.

This very small PR aims to fix that, improve cover loading reliability across terminals.

- no more stdin contention
- no per-fetch timeout
- correct font size cached once
- halfblocks() is the non-deprecated fallback if the one-time query fails.