### PR TITLE
Reduce the strikethrough in the queue

### DIFF
--- a/tui-module/src/queue.rs
+++ b/tui-module/src/queue.rs
@@ -8,7 +8,6 @@ use player_module::{AppResult, client::Client, notification::Notification};
 use ratatui::{
     crossterm::event::{Event, KeyCode, KeyEventKind},
     prelude::*,
-    style::Styled,
     widgets::*,
 };
 
@@ -55,8 +54,12 @@ impl QueueState {
 
                     let mut spans = vec![Span::from(format!("{} ", index + 1))];
                     spans.extend(title.spans);
+                    let spans: Vec<Span> = spans
+                        .into_iter()
+                        .map(|span| span.patch_style(style))
+                        .collect();
 
-                    Row::new(vec![Line::from(spans).set_style(style)])
+                    Row::new(vec![Line::from(spans)])
                 })
                 .collect(),
             true,


### PR DESCRIPTION
Before:
<img width="1712" height="90" alt="Capture d&#39;écran_20260617_221919" src="https://github.com/user-attachments/assets/4623e18d-4976-4da9-a27d-15f4a945c76a" />
After:
<img width="1712" height="90" alt="Capture d&#39;écran_20260617_222021" src="https://github.com/user-attachments/assets/a3cafbeb-d4ea-4a4a-9bf1-7623974b9777" />

Improves presentation (imo). IIRC was like that  before.
