### PR TITLE
About tab: format and scroll

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,6 +959,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 name = "controls-module"
 version = "1.0.0"
 dependencies = [
+ "html-escape",
  "qobuz-client",
  "serde",
  "time",
@@ -2500,6 +2501,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
 ]
 
 [[package]]
@@ -6785,6 +6795,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
 
 [[package]]
 name = "utf8_iter"

--- a/controls-module/Cargo.toml
+++ b/controls-module/Cargo.toml
@@ -12,3 +12,4 @@ qobuz-client = { version = "*", path = "../qobuz-client" }
 tokio.workspace = true
 serde.workspace = true
 time.workspace = true
+html-escape = "0.2"

--- a/controls-module/src/models/mapper.rs
+++ b/controls-module/src/models/mapper.rs
@@ -181,67 +181,12 @@ fn sanitize_html(source: Option<String>) -> Option<String> {
         }
     }
 
-    let data = decode_entities(data.trim());
+    let data = html_escape::decode_html_entities(data.trim());
     if data.is_empty() {
         return None;
     }
 
-    Some(data)
-}
-
-fn decode_entities(input: &str) -> String {
-    let mut out = String::with_capacity(input.len());
-    let mut rest = input;
-
-    while let Some(amp) = rest.find('&') {
-        out.push_str(&rest[..amp]);
-        let after = &rest[amp..];
-
-        if let Some(semi) = after.find(';')
-            && let Some(decoded) = decode_entity(&after[1..semi])
-        {
-            out.push(decoded);
-            rest = &after[semi + 1..];
-            continue;
-        }
-
-        out.push('&');
-        rest = &after[1..];
-    }
-
-    out.push_str(rest);
-    out
-}
-
-fn decode_entity(entity: &str) -> Option<char> {
-    if let Some(num) = entity.strip_prefix('#') {
-        let code = match num.strip_prefix(['x', 'X']) {
-            Some(hex) => u32::from_str_radix(hex, 16).ok()?,
-            None => num.parse().ok()?,
-        };
-        return char::from_u32(code);
-    }
-
-    Some(match entity {
-        "amp" => '&',
-        "lt" => '<',
-        "gt" => '>',
-        "quot" => '"',
-        "apos" => '\'',
-        "nbsp" => ' ',
-        "copy" => '©',
-        "reg" => '®',
-        "hellip" => '…',
-        "mdash" => '—',
-        "ndash" => '–',
-        "laquo" => '«',
-        "raquo" => '»',
-        "lsquo" => '‘',
-        "rsquo" => '’',
-        "ldquo" => '“',
-        "rdquo" => '”',
-        _ => return None,
-    })
+    Some(data.into_owned())
 }
 
 fn image_to_string(value: qobuz_models::artist_page::Image) -> String {

--- a/controls-module/src/models/mapper.rs
+++ b/controls-module/src/models/mapper.rs
@@ -150,24 +150,98 @@ fn sanitize_html(source: Option<String>) -> Option<String> {
     }
 
     let mut data = String::new();
+    let mut tag = String::new();
     let mut inside = false;
 
     for c in source.chars() {
         if c == '<' {
             inside = true;
+            tag.clear();
             continue;
         }
         if c == '>' {
             inside = false;
+            let name = tag
+                .split(|c: char| c.is_whitespace() || c == '/')
+                .find(|s| !s.is_empty())
+                .unwrap_or("");
+            if name.eq_ignore_ascii_case("br") || name.eq_ignore_ascii_case("p") {
+                let trailing_newlines = data.chars().rev().take_while(|&c| c == '\n').count();
+                if trailing_newlines < 2 {
+                    data.push('\n');
+                }
+            }
             continue;
         }
 
-        if !inside {
+        if inside {
+            tag.push(c);
+        } else {
             data.push(c);
         }
     }
 
-    Some(data.replace("&copy", "©"))
+    let data = decode_entities(data.trim());
+    if data.is_empty() {
+        return None;
+    }
+
+    Some(data)
+}
+
+fn decode_entities(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+
+    while let Some(amp) = rest.find('&') {
+        out.push_str(&rest[..amp]);
+        let after = &rest[amp..];
+
+        if let Some(semi) = after.find(';')
+            && let Some(decoded) = decode_entity(&after[1..semi])
+        {
+            out.push(decoded);
+            rest = &after[semi + 1..];
+            continue;
+        }
+
+        out.push('&');
+        rest = &after[1..];
+    }
+
+    out.push_str(rest);
+    out
+}
+
+fn decode_entity(entity: &str) -> Option<char> {
+    if let Some(num) = entity.strip_prefix('#') {
+        let code = match num.strip_prefix(['x', 'X']) {
+            Some(hex) => u32::from_str_radix(hex, 16).ok()?,
+            None => num.parse().ok()?,
+        };
+        return char::from_u32(code);
+    }
+
+    Some(match entity {
+        "amp" => '&',
+        "lt" => '<',
+        "gt" => '>',
+        "quot" => '"',
+        "apos" => '\'',
+        "nbsp" => ' ',
+        "copy" => '©',
+        "reg" => '®',
+        "hellip" => '…',
+        "mdash" => '—',
+        "ndash" => '–',
+        "laquo" => '«',
+        "raquo" => '»',
+        "lsquo" => '‘',
+        "rsquo" => '’',
+        "ldquo" => '“',
+        "rdquo" => '”',
+        _ => return None,
+    })
 }
 
 fn image_to_string(value: qobuz_models::artist_page::Image) -> String {

--- a/tui-module/src/popup.rs
+++ b/tui-module/src/popup.rs
@@ -35,7 +35,7 @@ pub struct ArtistPopupState {
     description: Option<String>,
     image: Option<(StatefulProtocol, f32)>,
     selected_sub_tab: usize,
-    about_scroll: u16,
+    about_scroll: ScrollbarState,
     top_tracks: TrackList,
     id: u32,
 }
@@ -82,7 +82,7 @@ impl ArtistPopupState {
             description: artist_page.description,
             image,
             selected_sub_tab: 0,
-            about_scroll: 0,
+            about_scroll: ScrollbarState::default(),
             top_tracks: TrackList::new(artist_page.top_tracks),
             id: artist.id,
         };
@@ -115,17 +115,21 @@ impl ArtistPopupState {
     fn cycle_subtab_backwards(&mut self) {
         let count = self.tabs().len();
         self.selected_sub_tab = (self.selected_sub_tab + count - 1) % count;
-        self.about_scroll = 0;
+        self.about_scroll = ScrollbarState::default();
     }
 
     fn cycle_subtab(&mut self) {
         let count = self.tabs().len();
         self.selected_sub_tab = (self.selected_sub_tab + count + 1) % count;
-        self.about_scroll = 0;
+        self.about_scroll = ScrollbarState::default();
     }
 
     fn scroll_about(&mut self, delta: i16) {
-        self.about_scroll = self.about_scroll.saturating_add_signed(delta);
+        let position = self
+            .about_scroll
+            .get_position()
+            .saturating_add_signed(delta as isize);
+        self.about_scroll = self.about_scroll.position(position);
     }
 
     fn visible_tab_kinds(&self) -> Vec<TabKind> {
@@ -238,7 +242,7 @@ pub struct AlbumPopupState {
     bit_depth: Option<u32>,
     sampling_rate: Option<f32>,
     selected_sub_tab: usize,
-    about_scroll: u16,
+    about_scroll: ScrollbarState,
     id: String,
 }
 
@@ -275,7 +279,7 @@ impl AlbumPopupState {
             bit_depth: album.bit_depth,
             sampling_rate: album.sampling_rate,
             selected_sub_tab: 0,
-            about_scroll: 0,
+            about_scroll: ScrollbarState::default(),
             id: album.id,
         }
     }
@@ -328,17 +332,21 @@ impl AlbumPopupState {
     fn cycle_subtab_backwards(&mut self) {
         let count = self.tabs().len();
         self.selected_sub_tab = (self.selected_sub_tab + count - 1) % count;
-        self.about_scroll = 0;
+        self.about_scroll = ScrollbarState::default();
     }
 
     fn cycle_subtab(&mut self) {
         let count = self.tabs().len();
         self.selected_sub_tab = (self.selected_sub_tab + count + 1) % count;
-        self.about_scroll = 0;
+        self.about_scroll = ScrollbarState::default();
     }
 
     fn scroll_about(&mut self, delta: i16) {
-        self.about_scroll = self.about_scroll.saturating_add_signed(delta);
+        let position = self
+            .about_scroll
+            .get_position()
+            .saturating_add_signed(delta as isize);
+        self.about_scroll = self.about_scroll.position(position);
     }
 
     fn visible_tab_kinds(&self) -> Vec<AlbumTabKind> {
@@ -1198,7 +1206,7 @@ fn wrap_text(text: &str, width: u16) -> Vec<Line<'static>> {
     lines
 }
 
-fn render_about(frame: &mut Frame, area: Rect, description: &str, scroll: &mut u16) {
+fn render_about(frame: &mut Frame, area: Rect, description: &str, scroll: &mut ScrollbarState) {
     let [text_area, bar_area] =
         Layout::horizontal([Constraint::Min(0), Constraint::Length(2)]).areas(area);
 
@@ -1206,23 +1214,25 @@ fn render_about(frame: &mut Frame, area: Rect, description: &str, scroll: &mut u
     let total = lines.len() as u16;
     let viewport = text_area.height;
     let max_scroll = total.saturating_sub(viewport);
-    *scroll = (*scroll).min(max_scroll);
+
+    let position = scroll.get_position().min(max_scroll as usize);
+    *scroll = scroll
+        .position(position)
+        .content_length((max_scroll + 1) as usize)
+        .viewport_content_length(viewport as usize);
 
     frame.render_widget(
-        Paragraph::new(Text::from(lines)).scroll((*scroll, 0)),
+        Paragraph::new(Text::from(lines)).scroll((position as u16, 0)),
         text_area,
     );
 
     if total > viewport {
-        let mut state = ScrollbarState::new((max_scroll + 1) as usize)
-            .viewport_content_length(viewport as usize)
-            .position(*scroll as usize);
         frame.render_stateful_widget(
             Scrollbar::new(ScrollbarOrientation::VerticalRight)
                 .begin_symbol(None)
                 .end_symbol(None),
             bar_area,
-            &mut state,
+            scroll,
         );
     }
 }

--- a/tui-module/src/popup.rs
+++ b/tui-module/src/popup.rs
@@ -35,6 +35,7 @@ pub struct ArtistPopupState {
     description: Option<String>,
     image: Option<(StatefulProtocol, f32)>,
     selected_sub_tab: usize,
+    about_scroll: u16,
     top_tracks: TrackList,
     id: u32,
 }
@@ -81,6 +82,7 @@ impl ArtistPopupState {
             description: artist_page.description,
             image,
             selected_sub_tab: 0,
+            about_scroll: 0,
             top_tracks: TrackList::new(artist_page.top_tracks),
             id: artist.id,
         };
@@ -113,11 +115,17 @@ impl ArtistPopupState {
     fn cycle_subtab_backwards(&mut self) {
         let count = self.tabs().len();
         self.selected_sub_tab = (self.selected_sub_tab + count - 1) % count;
+        self.about_scroll = 0;
     }
 
     fn cycle_subtab(&mut self) {
         let count = self.tabs().len();
         self.selected_sub_tab = (self.selected_sub_tab + count + 1) % count;
+        self.about_scroll = 0;
+    }
+
+    fn scroll_about(&mut self, delta: i16) {
+        self.about_scroll = self.about_scroll.saturating_add_signed(delta);
     }
 
     fn visible_tab_kinds(&self) -> Vec<TabKind> {
@@ -230,6 +238,7 @@ pub struct AlbumPopupState {
     bit_depth: Option<u32>,
     sampling_rate: Option<f32>,
     selected_sub_tab: usize,
+    about_scroll: u16,
     id: String,
 }
 
@@ -266,6 +275,7 @@ impl AlbumPopupState {
             bit_depth: album.bit_depth,
             sampling_rate: album.sampling_rate,
             selected_sub_tab: 0,
+            about_scroll: 0,
             id: album.id,
         }
     }
@@ -318,11 +328,17 @@ impl AlbumPopupState {
     fn cycle_subtab_backwards(&mut self) {
         let count = self.tabs().len();
         self.selected_sub_tab = (self.selected_sub_tab + count - 1) % count;
+        self.about_scroll = 0;
     }
 
     fn cycle_subtab(&mut self) {
         let count = self.tabs().len();
         self.selected_sub_tab = (self.selected_sub_tab + count + 1) % count;
+        self.about_scroll = 0;
+    }
+
+    fn scroll_about(&mut self, delta: i16) {
+        self.about_scroll = self.about_scroll.saturating_add_signed(delta);
     }
 
     fn visible_tab_kinds(&self) -> Vec<AlbumTabKind> {
@@ -581,8 +597,7 @@ impl Popup {
                     frame.render_widget(Paragraph::new(hint).style(Style::new().dim()), content);
                 } else if album.selected_tab_kind() == Some(AlbumTabKind::About) {
                     let description = album.description.clone().unwrap_or_default();
-                    let paragraph = Paragraph::new(description).wrap(Wrap { trim: false });
-                    frame.render_widget(paragraph, content);
+                    render_about(frame, content, &description, &mut album.about_scroll);
                 } else if let Some(state) = album.current_state_mut() {
                     match state {
                         SelectedAlbumPopupSubtabMut::Tracks(track_list) => track_list.render(
@@ -699,8 +714,7 @@ impl Popup {
 
                 if artist.selected_tab_kind() == Some(TabKind::About) {
                     let description = artist.description.clone().unwrap_or_default();
-                    let paragraph = Paragraph::new(description).wrap(Wrap { trim: false });
-                    frame.render_widget(paragraph, content);
+                    render_about(frame, content, &description, &mut artist.about_scroll);
                 } else if let Some(state) = artist.current_state_mut() {
                     match state {
                         SelectedArtistPopupSubtabMut::Albums(album_list) => album_list.render(
@@ -856,6 +870,13 @@ impl Popup {
                         Ok(Output::Popup(Popup::Artist(state)))
                     }
                     _ => {
+                        if album_state.selected_tab_kind() == Some(AlbumTabKind::About) {
+                            if let Some(delta) = about_scroll_delta(key_event.code) {
+                                album_state.scroll_about(delta);
+                            }
+                            return Ok(Output::Consumed);
+                        }
+
                         if album_state.selected_tab_kind() == Some(AlbumTabKind::GoToArtist) {
                             if key_event.code == KeyCode::Enter {
                                 let state =
@@ -898,6 +919,13 @@ impl Popup {
                         Ok(Output::Consumed)
                     }
                     _ => {
+                        if artist_popup_state.selected_tab_kind() == Some(TabKind::About) {
+                            if let Some(delta) = about_scroll_delta(key_event.code) {
+                                artist_popup_state.scroll_about(delta);
+                            }
+                            return Ok(Output::Consumed);
+                        }
+
                         let artist_id = artist_popup_state.id;
                         let current_state = artist_popup_state.current_state_mut();
                         match current_state {
@@ -1122,6 +1150,80 @@ async fn open_track_album(track: &Track, client: &Client) -> AppResult<Output> {
         )))
     } else {
         Ok(Output::Consumed)
+    }
+}
+
+fn about_scroll_delta(code: KeyCode) -> Option<i16> {
+    match code {
+        KeyCode::Up | KeyCode::Char('k') => Some(-1),
+        KeyCode::Down | KeyCode::Char('j') => Some(1),
+        KeyCode::PageUp => Some(-10),
+        KeyCode::PageDown => Some(10),
+        _ => None,
+    }
+}
+
+fn wrap_text(text: &str, width: u16) -> Vec<Line<'static>> {
+    let width = (width as usize).max(1);
+    let mut lines = Vec::new();
+
+    for paragraph in text.lines() {
+        let mut current = String::new();
+        let mut current_len = 0;
+
+        for word in paragraph.split_whitespace() {
+            let word_len = word.chars().count();
+            let extra = if current_len == 0 {
+                word_len
+            } else {
+                word_len + 1
+            };
+
+            if current_len > 0 && current_len + extra > width {
+                lines.push(Line::from(std::mem::take(&mut current)));
+                current_len = 0;
+            }
+
+            if current_len > 0 {
+                current.push(' ');
+                current_len += 1;
+            }
+            current.push_str(word);
+            current_len += word_len;
+        }
+
+        lines.push(Line::from(current));
+    }
+
+    lines
+}
+
+fn render_about(frame: &mut Frame, area: Rect, description: &str, scroll: &mut u16) {
+    let [text_area, bar_area] =
+        Layout::horizontal([Constraint::Min(0), Constraint::Length(2)]).areas(area);
+
+    let lines = wrap_text(description, text_area.width);
+    let total = lines.len() as u16;
+    let viewport = text_area.height;
+    let max_scroll = total.saturating_sub(viewport);
+    *scroll = (*scroll).min(max_scroll);
+
+    frame.render_widget(
+        Paragraph::new(Text::from(lines)).scroll((*scroll, 0)),
+        text_area,
+    );
+
+    if total > viewport {
+        let mut state = ScrollbarState::new((max_scroll + 1) as usize)
+            .viewport_content_length(viewport as usize)
+            .position(*scroll as usize);
+        frame.render_stateful_widget(
+            Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                .begin_symbol(None)
+                .end_symbol(None),
+            bar_area,
+            &mut state,
+        );
     }
 }
 

--- a/web-module/templates/description.html
+++ b/web-module/templates/description.html
@@ -1,4 +1,4 @@
 <div class="surface">
   <h3 class="text-lg">About {{ title }}</h3>
-  <p>{{ description }}</p>
+  <p style="white-space: pre-line;">{{ description }}</p>
 </div>


### PR DESCRIPTION
Add scrolling for long descriptions in the about tab, rather than just cutting it after 12 lines.

Also clean a bit more the html, and actually handle the br, p, new line tags. 

Result:

<img width="1292" height="396" alt="image" src="https://github.com/user-attachments/assets/7e1d3f38-6bf7-463c-b5c3-a976a41b6f82" />

Caution: I had to edit the sanitize_html func in mapper, and I didn't check if you're re-using it elsewhere (in gtk)

Edit; added one line fix for the web version as well (from wall of text to proper paragraphs)