### PR TITLE
Fix wrong album name for tracks played directly (favorites)

### DIFF
--- a/tui-module/src/app.rs
+++ b/tui-module/src/app.rs
@@ -823,7 +823,7 @@ pub fn get_current_state_without_image(
             (Some(tracklist.artist_name.clone()), track_image.cloned())
         }
         TracklistType::Tracks => (
-            track.as_ref().map(|x| x.title.clone()),
+            track.as_ref().and_then(|x| x.album_title.clone()),
             track_image.cloned(),
         ),
     };


### PR DESCRIPTION
The player bar shows track.title and entity_title so for a single track from favorites both lines show the track name.

switched to use album_title as it's already provided

Solves https://github.com/SofusA/qobine/pull/424#issuecomment-4768646642