### PR TITLE
Tui small optimizations & playlist duration fix

### DIFF
--- a/player-module/src/client.rs
+++ b/player-module/src/client.rs
@@ -422,7 +422,10 @@ impl Client {
     pub async fn remove_favorite_track(&self, id: u32) -> Result<()> {
         let client = self.get_client().await?;
         client.remove_favorite_track(id).await?;
-        self.favorites_cache.clear().await;
+        if let Some(mut cache) = self.favorites_cache.get().await {
+            cache.tracks.retain(|track| track.id != id);
+            self.favorites_cache.set(cache).await;
+        }
         Ok(())
     }
 
@@ -436,7 +439,10 @@ impl Client {
     pub async fn remove_favorite_album(&self, id: &str) -> Result<()> {
         let client = self.get_client().await?;
         client.remove_favorite_album(id).await?;
-        self.favorites_cache.clear().await;
+        if let Some(mut cache) = self.favorites_cache.get().await {
+            cache.albums.retain(|album| album.id != id);
+            self.favorites_cache.set(cache).await;
+        }
         Ok(())
     }
 
@@ -450,7 +456,10 @@ impl Client {
     pub async fn remove_favorite_artist(&self, id: u32) -> Result<()> {
         let client = self.get_client().await?;
         client.remove_favorite_artist(id).await?;
-        self.favorites_cache.clear().await;
+        if let Some(mut cache) = self.favorites_cache.get().await {
+            cache.artists.retain(|artist| artist.id != id);
+            self.favorites_cache.set(cache).await;
+        }
         Ok(())
     }
 
@@ -464,7 +473,10 @@ impl Client {
     pub async fn remove_favorite_playlist(&self, id: u32) -> Result<()> {
         let client = self.get_client().await?;
         client.remove_favorite_playlist(id).await?;
-        self.favorites_cache.clear().await;
+        if let Some(mut cache) = self.favorites_cache.get().await {
+            cache.playlists.retain(|playlist| playlist.id != id);
+            self.favorites_cache.set(cache).await;
+        }
         Ok(())
     }
 

--- a/player-module/src/player.rs
+++ b/player-module/src/player.rs
@@ -354,7 +354,6 @@ impl Player {
             self.sink.clear()?;
             self.next_track_is_queried = false;
             self.set_target_status(Status::Paused);
-            self.position.send(Default::default())?;
             self.broadcast_tracklist(tracklist).await?;
         }
 

--- a/tui-module/src/app.rs
+++ b/tui-module/src/app.rs
@@ -568,28 +568,27 @@ impl App {
                 }
             }
             Output::AddTrackToPlaylistPopup(track) => {
-                let playlists_res = self.client.favorites().await.map(|favs| {
-                    favs.playlists
-                        .into_iter()
-                        .filter(|p| p.is_owned)
-                        .map(|x| x.into())
-                        .collect::<Vec<_>>()
-                });
+                let playlists = self
+                    .favorites
+                    .playlists
+                    .all_items()
+                    .iter()
+                    .filter(|p| p.is_owned)
+                    .cloned()
+                    .collect();
 
-                if let Ok(playlists) = playlists_res {
-                    let mut popups = match std::mem::take(&mut self.app_state) {
-                        AppState::Popup(v) => v,
-                        other => {
-                            self.app_state = other;
-                            Vec::new()
-                        }
-                    };
+                let mut popups = match std::mem::take(&mut self.app_state) {
+                    AppState::Popup(v) => v,
+                    other => {
+                        self.app_state = other;
+                        Vec::new()
+                    }
+                };
 
-                    popups.push(Popup::Track(TrackPopupState::new(track, playlists)));
+                popups.push(Popup::Track(TrackPopupState::new(track, playlists)));
 
-                    self.app_state = AppState::Popup(popups);
-                    self.should_draw = true;
-                }
+                self.app_state = AppState::Popup(popups);
+                self.should_draw = true;
             }
             Output::AddTrackToPlaylistAndPopPopup((track_id, playlist_id)) => {
                 match self

--- a/tui-module/src/now_playing.rs
+++ b/tui-module/src/now_playing.rs
@@ -26,8 +26,7 @@ pub fn render(
         None => return,
     };
 
-    let title = get_status(state.status).to_string();
-    let block = block(Some(&title));
+    let block = block(Some(get_status(state.status)));
 
     let length = state
         .image


### PR DESCRIPTION
* idle 100ms tick gate
* popup built from in memory playlists
* remove path cache retain (todo addpath cache)
* drop per-render to_string()
* drop duplicate position send

and also noticed that the playlist lenght was not updated after adding a track (tui)  (stayed at 00:00), so this branch also contains the fix. Can cherry pick the second commit if you don't want the first one.