### PR TITLE
Make PlaylistSimpleImage.rectangle optional

### DIFF
--- a/controls-module/src/models/mapper.rs
+++ b/controls-module/src/models/mapper.rs
@@ -308,7 +308,7 @@ pub fn parse_playlist_simple(
         title: playlist.name,
         duration_seconds: playlist.duration as u32,
         tracks_count: playlist.tracks_count as u32,
-        image: Some(playlist.image.rectangle),
+        image: playlist.image.rectangle,
         owner: playlist.owner,
     }
 }

--- a/qobuz-client/src/qobuz_models/playlist.rs
+++ b/qobuz-client/src/qobuz_models/playlist.rs
@@ -89,6 +89,8 @@ pub struct PlaylistSimple {
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PlaylistSimpleImage {
-    pub rectangle: String,
+    #[serde(default)]
+    pub rectangle: Option<String>,
+    #[serde(default)]
     pub covers: Vec<String>,
 }


### PR DESCRIPTION
## Summary

Qobuz's API does not always include the `rectangle` field on `PlaylistSimpleImage`, which causes deserialization to fail at app launch with errors like:

```
Failed to deserialize json: missing field `rectangle` at line 1 column 15784
```

Reproduced on the released `qobuz-player 0.10.2` and confirmed against current `main` — the struct is unchanged.

This PR marks the field as optional and propagates that through the mapper. `PlaylistSimple.image` in `controls-module` is already `Option<String>`, so the call site only loses a `Some(...)` wrap.

## Changes

- `qobuz-client/src/qobuz_models/playlist.rs`: `rectangle: String` → `rectangle: Option<String>` with `#[serde(default)]`. Same `#[serde(default)]` added to `covers` for the same robustness reason.
- `controls-module/src/models/mapper.rs`: `image: Some(playlist.image.rectangle)` → `image: playlist.image.rectangle`.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo install --path tui-module --force --locked` builds clean
- [x] Patched `qobine-tui` launches against a real account that previously hit the error