### PR TITLE
respect the configured cache directory at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ todo.txt
 result*
 node_modules
 repo
+.DS_Store

--- a/cli-module/src/lib.rs
+++ b/cli-module/src/lib.rs
@@ -267,14 +267,6 @@ pub fn spawn_clean_up_mut(
     });
 }
 
-pub fn default_audio_cache(path: Option<PathBuf>) -> PathBuf {
-    path.unwrap_or_else(|| {
-        let mut cache_dir = std::env::temp_dir();
-        cache_dir.push("qobine-cache");
-        cache_dir
-    })
-}
-
 pub async fn default_audio_quality(
     database: &Database,
     args: Option<AudioQuality>,
@@ -289,7 +281,7 @@ pub async fn default_audio_quality(
 }
 
 pub async fn create_player(
-    audio_cache: PathBuf,
+    audio_cache: Option<PathBuf>,
     database: Arc<Database>,
     client: Arc<Client>,
     broadcast: Arc<NotificationBroadcast>,
@@ -299,6 +291,7 @@ pub async fn create_player(
 ) -> AppResult<Player> {
     let tracklist = database.get_tracklist().await.unwrap_or_default();
     let configuration = database.get_configuration().await?;
+    let audio_cache = audio_cache.unwrap_or(configuration.cache_directory);
 
     let state_change_delay = state_change_delay_ms.map(Duration::from_millis);
     let sample_rate_change_delay = sample_rate_change_delay_ms.map(Duration::from_millis);

--- a/connect-module/src/main.rs
+++ b/connect-module/src/main.rs
@@ -1,8 +1,8 @@
 #[cfg(feature = "gpio")]
 use cli_module::GpioArgs;
 use cli_module::{
-    ConnectNameArgs, DelayArgs, SharedArgs, SharedCommands, create_player, default_audio_cache,
-    default_audio_quality, error_exit, get_client, handle_shared_commands, spawn_clean_up,
+    ConnectNameArgs, DelayArgs, SharedArgs, SharedCommands, create_player, default_audio_quality,
+    error_exit, get_client, handle_shared_commands, spawn_clean_up,
 };
 use player_module::{AppResult, database::Database, notification::NotificationBroadcast};
 use std::sync::Arc;
@@ -63,10 +63,9 @@ pub async fn run() -> AppResult<()> {
     let client = Arc::new(client);
 
     let broadcast = Arc::new(NotificationBroadcast::new());
-    let audio_cache = default_audio_cache(args.shared.audio_cache);
 
     let mut player = create_player(
-        audio_cache,
+        args.shared.audio_cache,
         database.clone(),
         client.clone(),
         broadcast.clone(),

--- a/disconnect-module/src/main.rs
+++ b/disconnect-module/src/main.rs
@@ -1,6 +1,6 @@
 use cli_module::{
-    DelayArgs, SharedArgs, SharedCommands, create_player, default_audio_cache,
-    default_audio_quality, error_exit, get_client, handle_shared_commands, spawn_clean_up,
+    DelayArgs, SharedArgs, SharedCommands, create_player, default_audio_quality, error_exit,
+    get_client, handle_shared_commands, spawn_clean_up,
 };
 use disconnect_module::{DisconnectClientConfig, spawn_disconnect};
 use std::sync::Arc;
@@ -67,10 +67,9 @@ pub async fn run() -> AppResult<()> {
     let client = Arc::new(client);
 
     let broadcast = Arc::new(NotificationBroadcast::new());
-    let audio_cache = default_audio_cache(args.shared.audio_cache);
 
     let mut player = create_player(
-        audio_cache,
+        args.shared.audio_cache,
         database.clone(),
         client.clone(),
         broadcast.clone(),

--- a/gtk-module/src/main.rs
+++ b/gtk-module/src/main.rs
@@ -44,7 +44,7 @@ pub async fn run() -> AppResult<()> {
     let broadcast = Arc::new(NotificationBroadcast::new());
 
     let mut player = create_player(
-        configuration.cache_directory,
+        None,
         database.clone(),
         client.clone(),
         broadcast.clone(),

--- a/rfid-module/src/main.rs
+++ b/rfid-module/src/main.rs
@@ -2,8 +2,8 @@
 use cli_module::GpioArgs;
 use cli_module::{
     ConnectArgs, DelayArgs, DisconnectArgs, RfidArgs, SharedArgs, SharedCommands, create_player,
-    default_audio_cache, default_audio_quality, error_exit, get_client, handle_shared_commands,
-    parse_disconnect_args, spawn_clean_up,
+    default_audio_quality, error_exit, get_client, handle_shared_commands, parse_disconnect_args,
+    spawn_clean_up,
 };
 use disconnect_module::{DisconnectClientConfig, spawn_disconnect};
 use rfid_module::{RfidState, spawn_rfid};
@@ -72,10 +72,9 @@ pub async fn run() -> AppResult<()> {
     let client = Arc::new(client);
 
     let broadcast = Arc::new(NotificationBroadcast::new());
-    let audio_cache = default_audio_cache(args.shared.audio_cache);
 
     let mut player = create_player(
-        audio_cache,
+        args.shared.audio_cache,
         database.clone(),
         client.clone(),
         broadcast.clone(),

--- a/tui-module/src/main.rs
+++ b/tui-module/src/main.rs
@@ -1,6 +1,6 @@
 use cli_module::{
-    ConnectArgs, SharedArgs, SharedCommands, create_player, default_audio_cache,
-    default_audio_quality, error_exit, get_client, handle_shared_commands, spawn_clean_up_mut,
+    ConnectArgs, SharedArgs, SharedCommands, create_player, default_audio_quality, error_exit,
+    get_client, handle_shared_commands, spawn_clean_up_mut,
 };
 use disconnect_module::{DisconnectClientConfig, spawn_disconnect};
 use futures::executor::block_on;
@@ -65,10 +65,9 @@ pub async fn run() -> AppResult<()> {
     let client = Arc::new(client);
 
     let broadcast = Arc::new(NotificationBroadcast::new());
-    let audio_cache = default_audio_cache(args.shared.audio_cache);
 
     let mut player = create_player(
-        audio_cache,
+        args.shared.audio_cache,
         database.clone(),
         client.clone(),
         broadcast.clone(),

--- a/web-module/src/main.rs
+++ b/web-module/src/main.rs
@@ -2,8 +2,8 @@
 use cli_module::GpioArgs;
 use cli_module::{
     ConnectArgs, DelayArgs, DisconnectArgs, RfidArgs, SharedArgs, SharedCommands, create_player,
-    default_audio_cache, default_audio_quality, error_exit, get_client, handle_shared_commands,
-    parse_disconnect_args, spawn_clean_up,
+    default_audio_quality, error_exit, get_client, handle_shared_commands, parse_disconnect_args,
+    spawn_clean_up,
 };
 use disconnect_module::{DisconnectClientConfig, spawn_disconnect};
 use rfid_module::{RfidState, spawn_rfid};
@@ -91,10 +91,9 @@ pub async fn run() -> AppResult<()> {
     let client = Arc::new(client);
 
     let broadcast = Arc::new(NotificationBroadcast::new());
-    let audio_cache = default_audio_cache(args.shared.audio_cache);
 
     let mut player = create_player(
-        audio_cache,
+        args.shared.audio_cache,
         database.clone(),
         client.clone(),
         broadcast.clone(),


### PR DESCRIPTION
Currently the setting is not honored after a restart of the player.