### PR TITLE
DRAFT: qobine-connect cross compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,6 +941,7 @@ dependencies = [
  "qonductor",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,7 @@ dependencies = [
  "gpio-module",
  "player-module",
  "qonductor",
+ "rustls",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1859,21 +1860,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2600,22 +2586,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -3478,23 +3448,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3826,47 +3779,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.13.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -4388,9 +4304,8 @@ dependencies = [
 
 [[package]]
 name = "qonductor"
-version = "0.1.0-alpha.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e382869c16a2a73795b344631b73fb03651cbb2403dc6d61071655f613622f9"
+version = "0.1.0-alpha.6"
+source = "git+https://github.com/fengalin/qonductor?branch=tls-features#cc2c31fc15f21de8a114d56e1bd9fe18fbbcab3d"
 dependencies = [
  "async-stream",
  "axum",
@@ -4907,12 +4822,10 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4923,7 +4836,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -5151,6 +5063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -6394,16 +6307,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6433,9 +6336,11 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
- "native-tls",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tungstenite",
 ]
 
@@ -6700,8 +6605,9 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "native-tls",
  "rand 0.8.6",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,9 @@ mime = "0.3"
 mime_guess = "2"
 rand = "0.10"
 regex = "1"
-reqwest = { version = "0.12", features = ["rustls-tls", "cookies", "json", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["charset", "http2", "system-proxy", "rustls-tls", "cookies", "json", "stream"] }
+# select the rustls provider
+rustls = { version = "0.23", features = ["aws-lc-rs"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 snafu = "0.9"
@@ -58,7 +60,9 @@ tui-input = "0.15"
 image = "0.25"
 skabelon = "0.2.2"
 parking_lot = "0.12.5"
-qonductor = "0.1.0-alpha.5"
+# FIXME: use qonductor version when tls-features PR is merged
+#qonductor = { version = "0.1.0-alpha.5", default-features = false }
+qonductor = { git = "https://github.com/fengalin/qonductor", commit = "cc2c31fc15f21de8a114d56e1bd9fe18fbbcab3d", branch = "tls-features", default-features = false, features = ["rustls-native-roots"] }
 keepawake = "0.6.0"
 libc = "0.2.186"
 aes = "0.9"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,15 @@
+[build]
+# this is suitable to cross-compile qobine-connect
+# other binaries would require adding dependencies
+# with proper versions.
+#
+# cross-compile qobine-connect for Raspberry Pi 3B+:
+#
+# ```
+# cargo install cross --git https://github.com/cross-rs/cross
+# cross build --release --target aarch64-unknown-linux-gnu --bin qobine-connect
+#```
+pre-build = [
+    "dpkg --add-architecture $CROSS_DEB_ARCH", 
+    "apt-get update && apt-get --assume-yes install libasound2-dev:$CROSS_DEB_ARCH"
+]    

--- a/connect-module/Cargo.toml
+++ b/connect-module/Cargo.toml
@@ -25,3 +25,4 @@ tracing.workspace = true
 
 # binary dependencies
 clap.workspace = true
+tracing-subscriber.workspace = true

--- a/connect-module/Cargo.toml
+++ b/connect-module/Cargo.toml
@@ -20,6 +20,7 @@ gpio-module = { version = "*", path = "../gpio-module", optional = true }
 cli-module = { version = "*", path = "../cli-module" }
 
 qonductor.workspace = true
+rustls.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 

--- a/connect-module/src/lib.rs
+++ b/connect-module/src/lib.rs
@@ -174,6 +174,10 @@ impl ConnectState {
         connect_name: String,
         connect_port: u16,
     ) -> qonductor::Result<()> {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .expect("rustls aws-lc-rs feature selected");
+
         let mut manager = SessionManager::start(connect_port, app_id).await?;
 
         let mut session = manager.add_device(DeviceConfig::new(connect_name)).await?;

--- a/connect-module/src/main.rs
+++ b/connect-module/src/main.rs
@@ -41,6 +41,8 @@ async fn main() {
 }
 
 pub async fn run() -> AppResult<()> {
+    tracing_subscriber::fmt().init();
+
     let args = Arguments::parse();
     let database = Arc::new(Database::new().await?);
     let headless = true;


### PR DESCRIPTION
This PR aims at easing cross-compilation of `qobine-connect` for use in headless mode on a resource limited system. This is done by taking advantage of the [`cross` command](https://github.com/cross-rs/cross).

See the second commit message for details regarding removing `openssl` as a dependency. I went this route because `openssl` version in the `cross` docker image wasn't compliant with what  the crate `openssl-sys` expects. Since `qobine` selects `rustls` for `reqwest`, I decided to enforce this until `openssl` was no longer pulled in the dependency tree.

This is marked as DRAFT because it depends on the following `qonductor` PR: https://github.com/nickblt/qonductor/pull/10

Validated:

* `qobine-connect` cross-compiled for Raspberry Pi 3B+.
* `qobine-connect` compiled for local machine.
* `qobine-tui` compiled for local machine.