### PR TITLE
qobuz-client: redirect to hostname in headless mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,6 +941,7 @@ dependencies = [
  "qonductor",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2502,6 +2502,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
+
+[[package]]
 name = "html-escape"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4360,6 +4371,7 @@ dependencies = [
  "ctr",
  "futures",
  "hkdf 0.13.0",
+ "hostname",
  "md5",
  "open",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ clap = { version = "4", features = ["derive", "env"] }
 rust-embed = { version = "8", features = ["axum", "tokio", "mime_guess"] }
 dirs = "6"
 futures = "0.3"
+hostname = "0.4"
 md5 = "0.8"
 mime = "0.3"
 mime_guess = "2"

--- a/connect-module/Cargo.toml
+++ b/connect-module/Cargo.toml
@@ -25,3 +25,4 @@ tracing.workspace = true
 
 # binary dependencies
 clap.workspace = true
+tracing-subscriber.workspace = true

--- a/connect-module/src/main.rs
+++ b/connect-module/src/main.rs
@@ -41,6 +41,8 @@ async fn main() {
 }
 
 pub async fn run() -> AppResult<()> {
+    tracing_subscriber::fmt().init();
+
     let args = Arguments::parse();
     let database = Arc::new(Database::new().await?);
     let headless = true;

--- a/qobuz-client/Cargo.toml
+++ b/qobuz-client/Cargo.toml
@@ -29,6 +29,7 @@ stream-download.workspace = true
 bytes.workspace = true
 futures.workspace = true
 parking_lot.workspace = true
+hostname.workspace = true
 
 [dev-dependencies]
 controls-module = { version = "*", path = "../controls-module" }

--- a/qobuz-client/src/client.rs
+++ b/qobuz-client/src/client.rs
@@ -197,11 +197,11 @@ impl Display for Endpoint {
 }
 
 pub async fn browser_oauth_login(headless: bool, app_id: &str) -> Result<OAuthResult> {
-    let listener = TcpListener::bind("127.0.0.1:0").map_err(|_| Error::Login)?;
-    let port = listener.local_addr().map_err(|_| Error::Login)?.port();
+    let listener = TcpListener::bind("0.0.0.0:0").map_err(|_| Error::Login)?;
+    let local_addr = listener.local_addr().map_err(|_| Error::Login)?;
     drop(listener);
 
-    let oauth_url = build_oauth_url(app_id, port);
+    let oauth_url = build_oauth_url(app_id, local_addr.port());
 
     let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(1);
 
@@ -220,7 +220,7 @@ pub async fn browser_oauth_login(headless: bool, app_id: &str) -> Result<OAuthRe
         }),
     );
 
-    let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{port}"))
+    let listener = tokio::net::TcpListener::bind(local_addr)
         .await
         .map_err(|_| Error::Login)?;
 
@@ -231,7 +231,9 @@ pub async fn browser_oauth_login(headless: bool, app_id: &str) -> Result<OAuthRe
     println!("Login to Qobuz in browser...");
     if headless {
         let manual_oauth_url = format!(
-            "https://www.qobuz.com/signin/oauth?ext_app_id={app_id}&redirect_url=http%3A%2F%2Flocalhost"
+            "https://www.qobuz.com/signin/oauth?ext_app_id={app_id}&redirect_url=http%3A%2F%2F{}:{}",
+            hostname::get().map_err(|_| Error::Login)?.display(),
+            local_addr.port(),
         );
 
         println!("Headless? Open this URL on another device instead:");


### PR DESCRIPTION
In headless mode, the url was redirecting the authentication result to localhost instead of the actual hostname where the authentication token was needed.

Also listen on all interfaces.