### PR TITLE
macOS now playing integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -130,7 +130,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -138,6 +138,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "apple-cf"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba5e8f49a0239ddb14da08ad41bb28b46880252bf4831380de20709c996574"
+dependencies = [
+ "doom-fish-utils 0.2.1",
+]
 
 [[package]]
 name = "approx"
@@ -1527,6 +1536,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
+]
+
+[[package]]
+name = "doom-fish-utils"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075caf2993a45abe1c2e60d8d1514ce43f947fcbcd31de19db0075e80e20c6a7"
+
+[[package]]
+name = "doom-fish-utils"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c801f6c2a0db1a1909d89fc395b9dccc594de9ef599659fbde9bb3b55ef67f9f"
+dependencies = [
+ "crossbeam-queue",
+ "futures-util",
 ]
 
 [[package]]
@@ -3332,14 +3357,10 @@ dependencies = [
 name = "macos-module"
 version = "1.0.0"
 dependencies = [
- "block2",
+ "apple-cf",
  "controls-module",
  "dispatch2",
- "objc2",
- "objc2-app-kit",
- "objc2-core-foundation",
- "objc2-foundation",
- "objc2-media-player",
+ "mediaplayer",
  "player-module",
  "reqwest 0.12.28",
  "tokio",
@@ -3399,6 +3420,17 @@ dependencies = [
  "mio",
  "socket-pktinfo",
  "socket2",
+]
+
+[[package]]
+name = "mediaplayer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707f1ad053bddf7646f6a525a0b2c74cff23676a792e050b2d58e38c733467fb"
+dependencies = [
+ "apple-cf",
+ "doom-fish-utils 0.3.3",
+ "libc",
 ]
 
 [[package]]
@@ -3759,16 +3791,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-app-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
 name = "objc2-audio-toolbox"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3860,20 +3882,6 @@ dependencies = [
  "libc",
  "objc2",
  "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-media-player"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f2a98483f6e76313cb85a5a185eaa3cda86a177b13a8852d56cbd0085bf635"
-dependencies = [
- "bitflags 2.13.0",
- "block2",
- "objc2",
- "objc2-app-kit",
- "objc2-core-foundation",
- "objc2-foundation",
 ]
 
 [[package]]
@@ -5677,7 +5685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6266,7 +6274,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6831,7 +6839,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,6 +1505,7 @@ checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
+ "libc",
  "objc2",
 ]
 
@@ -3328,6 +3329,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "macos-module"
+version = "1.0.0"
+dependencies = [
+ "block2",
+ "controls-module",
+ "dispatch2",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-media-player",
+ "player-module",
+ "reqwest 0.12.28",
+ "tokio",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3741,6 +3759,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-audio-toolbox"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3832,6 +3860,20 @@ dependencies = [
  "libc",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-media-player"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85f2a98483f6e76313cb85a5a185eaa3cda86a177b13a8852d56cbd0085bf635"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -6737,6 +6779,7 @@ dependencies = [
  "futures",
  "image",
  "keepawake",
+ "macos-module",
  "mpris-module",
  "num-traits",
  "player-module",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,13 +78,6 @@ tower-http = { version = "0.7", features = ["limit"] }
 futures-util = "0.3"
 html-escape = "0.2"
 num-traits = "0.2"
-objc2 = "0.6"
-objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSObject", "NSString", "NSDictionary", "NSValue", "NSData"] }
-objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSImage"] }
-objc2-core-foundation = { version = "0.3", default-features = false, features = ["std", "CFRunLoop", "CFCGTypes"] }
-objc2-media-player = { version = "0.3", default-features = false, features = ["std", "MPNowPlayingInfoCenter", "MPRemoteCommandCenter", "MPRemoteCommand", "MPRemoteCommandEvent", "MPMediaItem", "block2", "objc2-app-kit", "objc2-core-foundation"] }
-block2 = "0.6"
-dispatch2 = "0.3"
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ members = [
   "gtk-module",
   "disconnect-server-module",
   "disconnect-module",
-  "player-module"
+  "player-module",
+  "macos-module"
 ]
 resolver = "2"
 
@@ -77,6 +78,13 @@ tower-http = { version = "0.7", features = ["limit"] }
 futures-util = "0.3"
 html-escape = "0.2"
 num-traits = "0.2"
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSObject", "NSString", "NSDictionary", "NSValue", "NSData"] }
+objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSImage"] }
+objc2-core-foundation = { version = "0.3", default-features = false, features = ["std", "CFRunLoop", "CFCGTypes"] }
+objc2-media-player = { version = "0.3", default-features = false, features = ["std", "MPNowPlayingInfoCenter", "MPRemoteCommandCenter", "MPRemoteCommand", "MPRemoteCommandEvent", "MPMediaItem", "block2", "objc2-app-kit", "objc2-core-foundation"] }
+block2 = "0.6"
+dispatch2 = "0.3"
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/macos-module/Cargo.toml
+++ b/macos-module/Cargo.toml
@@ -1,3 +1,6 @@
+[lints]
+workspace = true
+
 [package]
 name = "macos-module"
 
@@ -13,11 +16,7 @@ player-module = { version = "*", path = "../player-module" }
 tokio.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2.workspace = true
-objc2-foundation.workspace = true
-objc2-app-kit.workspace = true
-objc2-core-foundation.workspace = true
-objc2-media-player.workspace = true
-block2.workspace = true
-dispatch2.workspace = true
+mediaplayer = "0.4.3"
+apple-cf = "=0.7.1"
+dispatch2 = "0.3"
 reqwest.workspace = true

--- a/macos-module/Cargo.toml
+++ b/macos-module/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "macos-module"
+
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+repository.workspace = true
+
+[dependencies]
+controls-module = { version = "*", path = "../controls-module" }
+player-module = { version = "*", path = "../player-module" }
+
+tokio.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2.workspace = true
+objc2-foundation.workspace = true
+objc2-app-kit.workspace = true
+objc2-core-foundation.workspace = true
+objc2-media-player.workspace = true
+block2.workspace = true
+dispatch2.workspace = true
+reqwest.workspace = true

--- a/macos-module/README.md
+++ b/macos-module/README.md
@@ -1,0 +1,7 @@
+# macos-module
+
+Registers qobine as the macOS now-playing application through the MediaPlayer framework.
+
+Consumed by `tui-module`. The crate compiles to an empty library on other platforms.
+
+The MediaPlayer framework delivers remote command events through the main thread run loop, so consumers must keep the main thread pumping `run_main_loop()` while the tokio runtime runs on another thread, and call `stop_main_loop()` on shutdown.

--- a/macos-module/README.md
+++ b/macos-module/README.md
@@ -4,4 +4,6 @@ Registers qobine as the macOS now-playing application through the MediaPlayer fr
 
 Consumed by `tui-module`. The crate compiles to an empty library on other platforms.
 
-The MediaPlayer framework delivers remote command events through the main thread run loop, so consumers must keep the main thread pumping `run_main_loop()` while the tokio runtime runs on another thread, and call `stop_main_loop()` on shutdown.
+The MediaPlayer framework delivers remote command events through the main thread run loop, so consumers must keep the main thread pumping `MainLoop::run` while the tokio runtime runs on another thread, and stop it on shutdown through the paired `MainLoopStopper`.
+
+Building on macOS requires the Swift toolchain: the `mediaplayer` dependency compiles a bundled Swift package in its build script.

--- a/macos-module/README.md
+++ b/macos-module/README.md
@@ -4,6 +4,6 @@ Registers qobine as the macOS now-playing application through the MediaPlayer fr
 
 Consumed by `tui-module`. The crate compiles to an empty library on other platforms.
 
-The MediaPlayer framework delivers remote command events through the main thread run loop, so consumers must keep the main thread pumping `MainLoop::run` while the tokio runtime runs on another thread, and stop it on shutdown through the paired `MainLoopStopper`.
+The MediaPlayer framework delivers remote command events through the main thread run loop, so binaries wrap their async entry point in `run_with_main_loop`: it runs the tokio runtime on a separate thread while the main thread pumps the run loop, and tears the loop down when the entry point returns.
 
 Building on macOS requires the Swift toolchain: the `mediaplayer` dependency compiles a bundled Swift package in its build script.

--- a/macos-module/src/lib.rs
+++ b/macos-module/src/lib.rs
@@ -2,4 +2,4 @@
 mod now_playing;
 
 #[cfg(target_os = "macos")]
-pub use now_playing::{run_main_loop, spawn_now_playing, stop_main_loop};
+pub use now_playing::{MainLoop, MainLoopStopper, spawn_now_playing};

--- a/macos-module/src/lib.rs
+++ b/macos-module/src/lib.rs
@@ -2,4 +2,4 @@
 mod now_playing;
 
 #[cfg(target_os = "macos")]
-pub use now_playing::{MainLoop, MainLoopStopper, spawn_now_playing};
+pub use now_playing::{run_with_main_loop, spawn_now_playing};

--- a/macos-module/src/lib.rs
+++ b/macos-module/src/lib.rs
@@ -1,0 +1,5 @@
+#[cfg(target_os = "macos")]
+mod now_playing;
+
+#[cfg(target_os = "macos")]
+pub use now_playing::{run_main_loop, spawn_now_playing, stop_main_loop};

--- a/macos-module/src/now_playing.rs
+++ b/macos-module/src/now_playing.rs
@@ -1,5 +1,4 @@
 use std::{
-    ptr::NonNull,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -7,41 +6,60 @@ use std::{
     time::Duration,
 };
 
-use block2::RcBlock;
+use apple_cf::cf::CFRunLoop;
 use controls_module::{
     ExitSender, PositionReceiver, Status, StatusReceiver, TracklistReceiver, controls::Controls,
-    models::Track,
+    models::Track, tracklist::Tracklist,
 };
 use dispatch2::DispatchQueue;
-use objc2::{AnyThread, rc::Retained, runtime::AnyObject};
-use objc2_app_kit::NSImage;
-use objc2_core_foundation::{CFRunLoop, CGSize};
-use objc2_foundation::{NSData, NSMutableDictionary, NSNumber, NSString};
-use objc2_media_player::{
-    MPChangePlaybackPositionCommandEvent, MPMediaItemArtwork, MPMediaItemPropertyAlbumTitle,
-    MPMediaItemPropertyAlbumTrackNumber, MPMediaItemPropertyArtist, MPMediaItemPropertyArtwork,
-    MPMediaItemPropertyPlaybackDuration, MPMediaItemPropertyTitle, MPNowPlayingInfoCenter,
-    MPNowPlayingInfoPropertyElapsedPlaybackTime, MPNowPlayingInfoPropertyPlaybackRate,
-    MPNowPlayingPlaybackState, MPRemoteCommand, MPRemoteCommandCenter, MPRemoteCommandEvent,
-    MPRemoteCommandHandlerStatus,
+use mediaplayer::{
+    Artwork,
+    now_playing::{NowPlayingInfo, NowPlayingInfoCenter, NowPlayingMediaType, PlaybackState},
+    remote_commands::{CommandEvent, CommandToken, HandlerStatus, RemoteCommandCenter},
 };
 use player_module::player::Player;
 
-static EXITED: AtomicBool = AtomicBool::new(false);
+pub struct MainLoop {
+    exited: Arc<AtomicBool>,
+}
 
-pub fn run_main_loop() {
-    while !EXITED.load(Ordering::Acquire) {
-        CFRunLoop::run();
+pub struct MainLoopStopper {
+    exited: Arc<AtomicBool>,
+}
+
+impl Default for MainLoop {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
-pub fn stop_main_loop() {
-    EXITED.store(true, Ordering::Release);
-    DispatchQueue::main().exec_async(|| {
-        if let Some(run_loop) = CFRunLoop::current() {
-            run_loop.stop();
+impl MainLoop {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            exited: Arc::new(AtomicBool::new(false)),
         }
-    });
+    }
+
+    #[must_use]
+    pub fn stopper(&self) -> MainLoopStopper {
+        MainLoopStopper {
+            exited: self.exited.clone(),
+        }
+    }
+
+    pub fn run(&self) {
+        while !self.exited.load(Ordering::Acquire) {
+            let _ = CFRunLoop::current().run_in_default_mode(Duration::from_secs(1), false);
+        }
+    }
+}
+
+impl MainLoopStopper {
+    pub fn stop(&self) {
+        self.exited.store(true, Ordering::Release);
+        CFRunLoop::main().stop();
+    }
 }
 
 pub fn spawn_now_playing(player: &Player, exit_sender: &ExitSender) {
@@ -59,16 +77,16 @@ pub fn spawn_now_playing(player: &Player, exit_sender: &ExitSender) {
     ));
 }
 
-#[derive(Clone)]
 struct NowPlaying {
     title: String,
     artist: Option<String>,
     album: Option<String>,
     duration_seconds: f64,
-    track_number: u32,
     elapsed_seconds: f64,
     status: Status,
-    artwork: Option<Arc<Vec<u8>>>,
+    artwork_url: Option<String>,
+    queue_index: u64,
+    queue_count: u64,
 }
 
 async fn init(
@@ -81,67 +99,61 @@ async fn init(
     let mut exit_receiver = exit_sender.subscribe();
     let mut position_change_receiver = position_receiver.clone();
 
+    let center = NowPlayingInfoCenter::default_center();
+
+    let (token_sender, token_receiver) = tokio::sync::oneshot::channel();
     {
         let controls = controls.clone();
-        DispatchQueue::main().exec_async(move || register_commands(controls));
+        DispatchQueue::main().exec_async(move || {
+            let _ = token_sender.send(register_commands(&controls));
+        });
     }
+    let _tokens = token_receiver.await.ok();
 
     let mut current: Option<NowPlaying> = None;
-    let mut artwork_cache: Option<(String, Arc<Vec<u8>>)> = None;
+    let mut artwork_cache: Option<(String, Artwork)> = None;
     let mut last_position = *position_receiver.borrow();
 
-    let initial_track = tracklist_receiver.borrow().current_track().cloned();
-    if let Some(track) = initial_track {
-        let now_playing = build_now_playing(
-            track,
-            &mut artwork_cache,
-            &position_receiver,
-            &status_receiver,
-        )
-        .await;
-        current = Some(now_playing.clone());
-        push(Some(now_playing));
+    let now_playing = {
+        let tracklist = tracklist_receiver.borrow();
+        tracklist
+            .current_track()
+            .cloned()
+            .map(|track| build_now_playing(track, &tracklist, &position_receiver, &status_receiver))
+    };
+    if let Some(now_playing) = now_playing {
+        push(&center, Some(&now_playing), &mut artwork_cache).await;
+        current = Some(now_playing);
     }
 
     loop {
         tokio::select! {
-            Ok(_) = tracklist_receiver.changed() => {
-                let current_track = tracklist_receiver.borrow_and_update().current_track().cloned();
-
-                match current_track {
-                    Some(track) => {
-                        let now_playing = build_now_playing(
-                            track,
-                            &mut artwork_cache,
-                            &position_receiver,
-                            &status_receiver,
-                        )
-                        .await;
-                        current = Some(now_playing.clone());
-                        push(Some(now_playing));
-                    }
-                    None => {
-                        current = None;
-                        push(None);
-                    }
-                }
+            Ok(()) = tracklist_receiver.changed() => {
+                current = {
+                    let tracklist = tracklist_receiver.borrow_and_update();
+                    tracklist
+                        .current_track()
+                        .cloned()
+                        .map(|track| build_now_playing(track, &tracklist, &position_receiver, &status_receiver))
+                };
+                push(&center, current.as_ref(), &mut artwork_cache).await;
             },
-            Ok(_) = status_receiver.changed() => {
+            Ok(()) = status_receiver.changed() => {
                 let status = *status_receiver.borrow_and_update();
                 if let Some(now_playing) = current.as_mut() {
                     now_playing.status = status;
                     now_playing.elapsed_seconds = position_receiver.borrow().as_secs_f64();
-                    push(Some(now_playing.clone()));
+                    push(&center, Some(now_playing), &mut artwork_cache).await;
                 }
             },
-            Ok(_) = position_change_receiver.changed() => {
+            Ok(()) = position_change_receiver.changed() => {
                 let position = *position_change_receiver.borrow_and_update();
                 let jumped = position.abs_diff(last_position) > Duration::from_secs(3);
                 last_position = position;
 
                 if jumped && let Some(now_playing) = current.as_mut() {
                     now_playing.elapsed_seconds = position.as_secs_f64();
-                    push(Some(now_playing.clone()));
+                    push(&center, Some(now_playing), &mut artwork_cache).await;
                 }
             },
             Ok(exit) = exit_receiver.recv() => {
@@ -153,180 +165,125 @@ async fn init(
     }
 }
 
-async fn build_now_playing(
+fn build_now_playing(
     track: Track,
-    artwork_cache: &mut Option<(String, Arc<Vec<u8>>)>,
+    tracklist: &Tracklist,
     position_receiver: &PositionReceiver,
     status_receiver: &StatusReceiver,
 ) -> NowPlaying {
-    let artwork = fetch_artwork(artwork_cache, track.image.as_deref()).await;
     NowPlaying {
         title: track.title,
         artist: track.artist_name,
         album: track.album_title,
-        duration_seconds: track.duration_seconds as f64,
-        track_number: track.number,
+        duration_seconds: f64::from(track.duration_seconds),
         elapsed_seconds: position_receiver.borrow().as_secs_f64(),
         status: *status_receiver.borrow(),
-        artwork,
+        artwork_url: track.image,
+        queue_index: u64::try_from(tracklist.current_position()).unwrap_or_default(),
+        queue_count: u64::try_from(tracklist.total()).unwrap_or_default(),
     }
 }
 
-async fn fetch_artwork(
-    cache: &mut Option<(String, Arc<Vec<u8>>)>,
-    url: Option<&str>,
-) -> Option<Arc<Vec<u8>>> {
-    let url = url?;
-
-    if let Some((cached_url, bytes)) = cache
-        && cached_url == url
-    {
-        return Some(bytes.clone());
-    }
-
-    let response = reqwest::get(url).await.ok()?;
-    let bytes = Arc::new(response.bytes().await.ok()?.to_vec());
-    *cache = Some((url.to_string(), bytes.clone()));
-    Some(bytes)
-}
-
-fn push(now_playing: Option<NowPlaying>) {
-    DispatchQueue::main().exec_async(move || set_now_playing(now_playing));
-}
-
-fn set_now_playing(now_playing: Option<NowPlaying>) {
-    let center = unsafe { MPNowPlayingInfoCenter::defaultCenter() };
-
+async fn push(
+    center: &NowPlayingInfoCenter,
+    now_playing: Option<&NowPlaying>,
+    artwork_cache: &mut Option<(String, Artwork)>,
+) {
     let Some(now_playing) = now_playing else {
-        unsafe {
-            center.setNowPlayingInfo(None);
-            center.setPlaybackState(MPNowPlayingPlaybackState::Stopped);
-        }
+        center.clear();
+        center.set_playback_state(PlaybackState::Stopped);
         return;
     };
 
-    let info = NSMutableDictionary::<NSString, AnyObject>::new();
-
-    insert_string(
-        &info,
-        unsafe { MPMediaItemPropertyTitle },
-        &now_playing.title,
-    );
-    if let Some(artist) = &now_playing.artist {
-        insert_string(&info, unsafe { MPMediaItemPropertyArtist }, artist);
-    }
-    if let Some(album) = &now_playing.album {
-        insert_string(&info, unsafe { MPMediaItemPropertyAlbumTitle }, album);
-    }
+    let artwork = fetch_artwork(artwork_cache, now_playing.artwork_url.as_deref()).await;
 
     let rate = match now_playing.status {
         Status::Playing => 1.0,
         Status::Buffering | Status::Paused => 0.0,
     };
 
-    insert_number(
-        &info,
-        unsafe { MPMediaItemPropertyPlaybackDuration },
-        now_playing.duration_seconds,
-    );
-    insert_number(
-        &info,
-        unsafe { MPMediaItemPropertyAlbumTrackNumber },
-        f64::from(now_playing.track_number),
-    );
-    insert_number(
-        &info,
-        unsafe { MPNowPlayingInfoPropertyElapsedPlaybackTime },
-        now_playing.elapsed_seconds,
-    );
-    insert_number(&info, unsafe { MPNowPlayingInfoPropertyPlaybackRate }, rate);
+    let mut info = NowPlayingInfo::new()
+        .title(&now_playing.title)
+        .playback_duration(now_playing.duration_seconds)
+        .elapsed_playback_time(now_playing.elapsed_seconds)
+        .playback_rate(rate)
+        .playback_queue_index(now_playing.queue_index)
+        .playback_queue_count(now_playing.queue_count)
+        .media_type(NowPlayingMediaType::Audio);
 
-    if let Some(artwork) = now_playing.artwork.as_ref().and_then(make_artwork) {
-        info.insert(unsafe { MPMediaItemPropertyArtwork }, &artwork);
+    if let Some(artist) = &now_playing.artist {
+        info = info.artist(artist);
     }
+    if let Some(album) = &now_playing.album {
+        info = info.album_title(album);
+    }
+
+    center.set_now_playing_info_with_artwork(&info, artwork);
 
     let state = match now_playing.status {
-        Status::Playing | Status::Buffering => MPNowPlayingPlaybackState::Playing,
-        Status::Paused => MPNowPlayingPlaybackState::Paused,
+        Status::Playing | Status::Buffering => PlaybackState::Playing,
+        Status::Paused => PlaybackState::Paused,
     };
+    center.set_playback_state(state);
+}
 
-    unsafe {
-        center.setNowPlayingInfo(Some(&info));
-        center.setPlaybackState(state);
+async fn fetch_artwork<'a>(
+    cache: &'a mut Option<(String, Artwork)>,
+    url: Option<&str>,
+) -> Option<&'a Artwork> {
+    let url = url?;
+
+    let cached = cache
+        .as_ref()
+        .is_some_and(|(cached_url, _)| cached_url == url);
+    if !cached {
+        let artwork = download_artwork(url).await?;
+        *cache = Some((url.to_string(), artwork));
     }
+
+    cache.as_ref().map(|(_, artwork)| artwork)
 }
 
-fn insert_string(info: &NSMutableDictionary<NSString, AnyObject>, key: &NSString, value: &str) {
-    info.insert(key, &NSString::from_str(value));
+async fn download_artwork(url: &str) -> Option<Artwork> {
+    let response = reqwest::get(url).await.ok()?;
+    let bytes = response.bytes().await.ok()?;
+
+    let path = std::env::temp_dir().join(format!("qobine-artwork-{}.jpg", std::process::id()));
+    tokio::fs::write(&path, &bytes).await.ok()?;
+
+    let artwork = Artwork::from_path(path.to_str()?).ok();
+    let _ = tokio::fs::remove_file(&path).await;
+    artwork
 }
 
-fn insert_number(info: &NSMutableDictionary<NSString, AnyObject>, key: &NSString, value: f64) {
-    info.insert(key, &NSNumber::new_f64(value));
-}
-
-fn make_artwork(bytes: &Arc<Vec<u8>>) -> Option<Retained<MPMediaItemArtwork>> {
-    let data = NSData::with_bytes(bytes);
-    let image = NSImage::initWithData(NSImage::alloc(), &data)?;
-    let size = image.size();
-
-    let handler = RcBlock::new(move |_size: CGSize| NonNull::from(&*image));
-
-    Some(unsafe {
-        MPMediaItemArtwork::initWithBoundsSize_requestHandler(
-            MPMediaItemArtwork::alloc(),
-            size,
-            &handler,
-        )
-    })
-}
-
-fn register_commands(controls: Controls) {
-    let center = unsafe { MPRemoteCommandCenter::sharedCommandCenter() };
-
-    let play = unsafe { center.playCommand() };
-    let pause = unsafe { center.pauseCommand() };
-    let toggle = unsafe { center.togglePlayPauseCommand() };
-    let stop = unsafe { center.stopCommand() };
-    let next = unsafe { center.nextTrackCommand() };
-    let previous = unsafe { center.previousTrackCommand() };
-
-    add_command(&play, &controls, Controls::play);
-    add_command(&pause, &controls, Controls::pause);
-    add_command(&toggle, &controls, Controls::play_pause);
-    add_command(&stop, &controls, Controls::pause);
-    add_command(&next, &controls, Controls::next);
-    add_command(&previous, &controls, Controls::previous);
-
-    let handler = RcBlock::new(move |event: NonNull<MPRemoteCommandEvent>| {
-        let event = unsafe { event.as_ref() };
-        let Some(event) = event.downcast_ref::<MPChangePlaybackPositionCommandEvent>() else {
-            return MPRemoteCommandHandlerStatus::CommandFailed;
-        };
-        let position = unsafe { event.positionTime() }.max(0.0);
-        controls.seek(Duration::from_secs_f64(position));
-        MPRemoteCommandHandlerStatus::Success
-    });
-
-    unsafe {
-        center
-            .changePlaybackPositionCommand()
-            .addTargetWithHandler(&handler);
-
-        center.skipForwardCommand().setEnabled(false);
-        center.skipBackwardCommand().setEnabled(false);
-        center.seekForwardCommand().setEnabled(false);
-        center.seekBackwardCommand().setEnabled(false);
-        center.changePlaybackRateCommand().setEnabled(false);
-        center.changeRepeatModeCommand().setEnabled(false);
-        center.changeShuffleModeCommand().setEnabled(false);
-    }
-}
-
-fn add_command(command: &MPRemoteCommand, controls: &Controls, action: fn(&Controls)) {
+fn command_handler(
+    controls: &Controls,
+    action: fn(&Controls),
+) -> impl FnMut(CommandEvent) -> HandlerStatus + Send + 'static {
     let controls = controls.clone();
-    let handler = RcBlock::new(move |_event: NonNull<MPRemoteCommandEvent>| {
+    move |_event| {
         action(&controls);
-        MPRemoteCommandHandlerStatus::Success
-    });
-    unsafe { command.addTargetWithHandler(&handler) };
+        HandlerStatus::Success
+    }
+}
+
+fn register_commands(controls: &Controls) -> Vec<CommandToken> {
+    let center = RemoteCommandCenter::shared();
+
+    let seek_controls = controls.clone();
+
+    vec![
+        center.on_play(command_handler(controls, Controls::play)),
+        center.on_pause(command_handler(controls, Controls::pause)),
+        center.on_toggle_play_pause(command_handler(controls, Controls::play_pause)),
+        center.on_stop(command_handler(controls, Controls::pause)),
+        center.on_next_track(command_handler(controls, Controls::next)),
+        center.on_previous_track(command_handler(controls, Controls::previous)),
+        center.on_change_playback_position(move |event| {
+            if let Some(position) = event.position {
+                seek_controls.seek(Duration::from_secs_f64(position.max(0.0)));
+            }
+            HandlerStatus::Success
+        }),
+    ]
 }

--- a/macos-module/src/now_playing.rs
+++ b/macos-module/src/now_playing.rs
@@ -1,0 +1,332 @@
+use std::{
+    ptr::NonNull,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+use block2::RcBlock;
+use controls_module::{
+    ExitSender, PositionReceiver, Status, StatusReceiver, TracklistReceiver, controls::Controls,
+    models::Track,
+};
+use dispatch2::DispatchQueue;
+use objc2::{AnyThread, rc::Retained, runtime::AnyObject};
+use objc2_app_kit::NSImage;
+use objc2_core_foundation::{CFRunLoop, CGSize};
+use objc2_foundation::{NSData, NSMutableDictionary, NSNumber, NSString};
+use objc2_media_player::{
+    MPChangePlaybackPositionCommandEvent, MPMediaItemArtwork, MPMediaItemPropertyAlbumTitle,
+    MPMediaItemPropertyAlbumTrackNumber, MPMediaItemPropertyArtist, MPMediaItemPropertyArtwork,
+    MPMediaItemPropertyPlaybackDuration, MPMediaItemPropertyTitle, MPNowPlayingInfoCenter,
+    MPNowPlayingInfoPropertyElapsedPlaybackTime, MPNowPlayingInfoPropertyPlaybackRate,
+    MPNowPlayingPlaybackState, MPRemoteCommand, MPRemoteCommandCenter, MPRemoteCommandEvent,
+    MPRemoteCommandHandlerStatus,
+};
+use player_module::player::Player;
+
+static EXITED: AtomicBool = AtomicBool::new(false);
+
+pub fn run_main_loop() {
+    while !EXITED.load(Ordering::Acquire) {
+        CFRunLoop::run();
+    }
+}
+
+pub fn stop_main_loop() {
+    EXITED.store(true, Ordering::Release);
+    DispatchQueue::main().exec_async(|| {
+        if let Some(run_loop) = CFRunLoop::current() {
+            run_loop.stop();
+        }
+    });
+}
+
+pub fn spawn_now_playing(player: &Player, exit_sender: &ExitSender) {
+    let position_receiver = player.position();
+    let tracklist_receiver = player.tracklist();
+    let status_receiver = player.status();
+    let controls = player.controls();
+    let exit_sender = exit_sender.clone();
+    tokio::spawn(init(
+        position_receiver,
+        tracklist_receiver,
+        status_receiver,
+        controls,
+        exit_sender,
+    ));
+}
+
+#[derive(Clone)]
+struct NowPlaying {
+    title: String,
+    artist: Option<String>,
+    album: Option<String>,
+    duration_seconds: f64,
+    track_number: u32,
+    elapsed_seconds: f64,
+    status: Status,
+    artwork: Option<Arc<Vec<u8>>>,
+}
+
+async fn init(
+    position_receiver: PositionReceiver,
+    mut tracklist_receiver: TracklistReceiver,
+    mut status_receiver: StatusReceiver,
+    controls: Controls,
+    exit_sender: ExitSender,
+) {
+    let mut exit_receiver = exit_sender.subscribe();
+    let mut position_change_receiver = position_receiver.clone();
+
+    {
+        let controls = controls.clone();
+        DispatchQueue::main().exec_async(move || register_commands(controls));
+    }
+
+    let mut current: Option<NowPlaying> = None;
+    let mut artwork_cache: Option<(String, Arc<Vec<u8>>)> = None;
+    let mut last_position = *position_receiver.borrow();
+
+    let initial_track = tracklist_receiver.borrow().current_track().cloned();
+    if let Some(track) = initial_track {
+        let now_playing = build_now_playing(
+            track,
+            &mut artwork_cache,
+            &position_receiver,
+            &status_receiver,
+        )
+        .await;
+        current = Some(now_playing.clone());
+        push(Some(now_playing));
+    }
+
+    loop {
+        tokio::select! {
+            Ok(_) = tracklist_receiver.changed() => {
+                let current_track = tracklist_receiver.borrow_and_update().current_track().cloned();
+
+                match current_track {
+                    Some(track) => {
+                        let now_playing = build_now_playing(
+                            track,
+                            &mut artwork_cache,
+                            &position_receiver,
+                            &status_receiver,
+                        )
+                        .await;
+                        current = Some(now_playing.clone());
+                        push(Some(now_playing));
+                    }
+                    None => {
+                        current = None;
+                        push(None);
+                    }
+                }
+            },
+            Ok(_) = status_receiver.changed() => {
+                let status = *status_receiver.borrow_and_update();
+                if let Some(now_playing) = current.as_mut() {
+                    now_playing.status = status;
+                    now_playing.elapsed_seconds = position_receiver.borrow().as_secs_f64();
+                    push(Some(now_playing.clone()));
+                }
+            },
+            Ok(_) = position_change_receiver.changed() => {
+                let position = *position_change_receiver.borrow_and_update();
+                let jumped = position.abs_diff(last_position) > Duration::from_secs(3);
+                last_position = position;
+
+                if jumped && let Some(now_playing) = current.as_mut() {
+                    now_playing.elapsed_seconds = position.as_secs_f64();
+                    push(Some(now_playing.clone()));
+                }
+            },
+            Ok(exit) = exit_receiver.recv() => {
+                if exit {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+async fn build_now_playing(
+    track: Track,
+    artwork_cache: &mut Option<(String, Arc<Vec<u8>>)>,
+    position_receiver: &PositionReceiver,
+    status_receiver: &StatusReceiver,
+) -> NowPlaying {
+    let artwork = fetch_artwork(artwork_cache, track.image.as_deref()).await;
+    NowPlaying {
+        title: track.title,
+        artist: track.artist_name,
+        album: track.album_title,
+        duration_seconds: track.duration_seconds as f64,
+        track_number: track.number,
+        elapsed_seconds: position_receiver.borrow().as_secs_f64(),
+        status: *status_receiver.borrow(),
+        artwork,
+    }
+}
+
+async fn fetch_artwork(
+    cache: &mut Option<(String, Arc<Vec<u8>>)>,
+    url: Option<&str>,
+) -> Option<Arc<Vec<u8>>> {
+    let url = url?;
+
+    if let Some((cached_url, bytes)) = cache
+        && cached_url == url
+    {
+        return Some(bytes.clone());
+    }
+
+    let response = reqwest::get(url).await.ok()?;
+    let bytes = Arc::new(response.bytes().await.ok()?.to_vec());
+    *cache = Some((url.to_string(), bytes.clone()));
+    Some(bytes)
+}
+
+fn push(now_playing: Option<NowPlaying>) {
+    DispatchQueue::main().exec_async(move || set_now_playing(now_playing));
+}
+
+fn set_now_playing(now_playing: Option<NowPlaying>) {
+    let center = unsafe { MPNowPlayingInfoCenter::defaultCenter() };
+
+    let Some(now_playing) = now_playing else {
+        unsafe {
+            center.setNowPlayingInfo(None);
+            center.setPlaybackState(MPNowPlayingPlaybackState::Stopped);
+        }
+        return;
+    };
+
+    let info = NSMutableDictionary::<NSString, AnyObject>::new();
+
+    insert_string(
+        &info,
+        unsafe { MPMediaItemPropertyTitle },
+        &now_playing.title,
+    );
+    if let Some(artist) = &now_playing.artist {
+        insert_string(&info, unsafe { MPMediaItemPropertyArtist }, artist);
+    }
+    if let Some(album) = &now_playing.album {
+        insert_string(&info, unsafe { MPMediaItemPropertyAlbumTitle }, album);
+    }
+
+    let rate = match now_playing.status {
+        Status::Playing => 1.0,
+        Status::Buffering | Status::Paused => 0.0,
+    };
+
+    insert_number(
+        &info,
+        unsafe { MPMediaItemPropertyPlaybackDuration },
+        now_playing.duration_seconds,
+    );
+    insert_number(
+        &info,
+        unsafe { MPMediaItemPropertyAlbumTrackNumber },
+        f64::from(now_playing.track_number),
+    );
+    insert_number(
+        &info,
+        unsafe { MPNowPlayingInfoPropertyElapsedPlaybackTime },
+        now_playing.elapsed_seconds,
+    );
+    insert_number(&info, unsafe { MPNowPlayingInfoPropertyPlaybackRate }, rate);
+
+    if let Some(artwork) = now_playing.artwork.as_ref().and_then(make_artwork) {
+        info.insert(unsafe { MPMediaItemPropertyArtwork }, &artwork);
+    }
+
+    let state = match now_playing.status {
+        Status::Playing | Status::Buffering => MPNowPlayingPlaybackState::Playing,
+        Status::Paused => MPNowPlayingPlaybackState::Paused,
+    };
+
+    unsafe {
+        center.setNowPlayingInfo(Some(&info));
+        center.setPlaybackState(state);
+    }
+}
+
+fn insert_string(info: &NSMutableDictionary<NSString, AnyObject>, key: &NSString, value: &str) {
+    info.insert(key, &NSString::from_str(value));
+}
+
+fn insert_number(info: &NSMutableDictionary<NSString, AnyObject>, key: &NSString, value: f64) {
+    info.insert(key, &NSNumber::new_f64(value));
+}
+
+fn make_artwork(bytes: &Arc<Vec<u8>>) -> Option<Retained<MPMediaItemArtwork>> {
+    let data = NSData::with_bytes(bytes);
+    let image = NSImage::initWithData(NSImage::alloc(), &data)?;
+    let size = image.size();
+
+    let handler = RcBlock::new(move |_size: CGSize| NonNull::from(&*image));
+
+    Some(unsafe {
+        MPMediaItemArtwork::initWithBoundsSize_requestHandler(
+            MPMediaItemArtwork::alloc(),
+            size,
+            &handler,
+        )
+    })
+}
+
+fn register_commands(controls: Controls) {
+    let center = unsafe { MPRemoteCommandCenter::sharedCommandCenter() };
+
+    let play = unsafe { center.playCommand() };
+    let pause = unsafe { center.pauseCommand() };
+    let toggle = unsafe { center.togglePlayPauseCommand() };
+    let stop = unsafe { center.stopCommand() };
+    let next = unsafe { center.nextTrackCommand() };
+    let previous = unsafe { center.previousTrackCommand() };
+
+    add_command(&play, &controls, Controls::play);
+    add_command(&pause, &controls, Controls::pause);
+    add_command(&toggle, &controls, Controls::play_pause);
+    add_command(&stop, &controls, Controls::pause);
+    add_command(&next, &controls, Controls::next);
+    add_command(&previous, &controls, Controls::previous);
+
+    let handler = RcBlock::new(move |event: NonNull<MPRemoteCommandEvent>| {
+        let event = unsafe { event.as_ref() };
+        let Some(event) = event.downcast_ref::<MPChangePlaybackPositionCommandEvent>() else {
+            return MPRemoteCommandHandlerStatus::CommandFailed;
+        };
+        let position = unsafe { event.positionTime() }.max(0.0);
+        controls.seek(Duration::from_secs_f64(position));
+        MPRemoteCommandHandlerStatus::Success
+    });
+
+    unsafe {
+        center
+            .changePlaybackPositionCommand()
+            .addTargetWithHandler(&handler);
+
+        center.skipForwardCommand().setEnabled(false);
+        center.skipBackwardCommand().setEnabled(false);
+        center.seekForwardCommand().setEnabled(false);
+        center.seekBackwardCommand().setEnabled(false);
+        center.changePlaybackRateCommand().setEnabled(false);
+        center.changeRepeatModeCommand().setEnabled(false);
+        center.changeShuffleModeCommand().setEnabled(false);
+    }
+}
+
+fn add_command(command: &MPRemoteCommand, controls: &Controls, action: fn(&Controls)) {
+    let controls = controls.clone();
+    let handler = RcBlock::new(move |_event: NonNull<MPRemoteCommandEvent>| {
+        action(&controls);
+        MPRemoteCommandHandlerStatus::Success
+    });
+    unsafe { command.addTargetWithHandler(&handler) };
+}

--- a/macos-module/src/now_playing.rs
+++ b/macos-module/src/now_playing.rs
@@ -1,4 +1,5 @@
 use std::{
+    future::Future,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -19,46 +20,26 @@ use mediaplayer::{
 };
 use player_module::player::Player;
 
-pub struct MainLoop {
-    exited: Arc<AtomicBool>,
-}
+pub fn run_with_main_loop<F, Fut>(run: F)
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: Future<Output = ()>,
+{
+    let exited = Arc::new(AtomicBool::new(false));
 
-pub struct MainLoopStopper {
-    exited: Arc<AtomicBool>,
-}
-
-impl Default for MainLoop {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl MainLoop {
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            exited: Arc::new(AtomicBool::new(false)),
+    let thread_exited = exited.clone();
+    std::thread::spawn(move || {
+        match tokio::runtime::Runtime::new() {
+            Ok(runtime) => runtime.block_on(run()),
+            Err(err) => eprintln!("{err}"),
         }
-    }
 
-    #[must_use]
-    pub fn stopper(&self) -> MainLoopStopper {
-        MainLoopStopper {
-            exited: self.exited.clone(),
-        }
-    }
-
-    pub fn run(&self) {
-        while !self.exited.load(Ordering::Acquire) {
-            let _ = CFRunLoop::current().run_in_default_mode(Duration::from_secs(1), false);
-        }
-    }
-}
-
-impl MainLoopStopper {
-    pub fn stop(&self) {
-        self.exited.store(true, Ordering::Release);
+        thread_exited.store(true, Ordering::Release);
         CFRunLoop::main().stop();
+    });
+
+    while !exited.load(Ordering::Acquire) {
+        let _ = CFRunLoop::current().run_in_default_mode(Duration::from_secs(1), false);
     }
 }
 

--- a/tui-module/Cargo.toml
+++ b/tui-module/Cargo.toml
@@ -42,3 +42,6 @@ clap.workspace = true
 
 [target.'cfg(any(windows, target_os = "linux", target_os = "macos"))'.dependencies]
 keepawake = { workspace = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+macos-module = { version = "*", path = "../macos-module" }

--- a/tui-module/src/main.rs
+++ b/tui-module/src/main.rs
@@ -43,7 +43,10 @@ async fn main() {
 
 #[cfg(target_os = "macos")]
 fn main() {
-    std::thread::spawn(|| {
+    let main_loop = macos_module::MainLoop::new();
+    let stopper = main_loop.stopper();
+
+    std::thread::spawn(move || {
         match tokio::runtime::Runtime::new() {
             Ok(runtime) => {
                 if let Err(err) = runtime.block_on(run()) {
@@ -55,10 +58,10 @@ fn main() {
             }
         }
 
-        macos_module::stop_main_loop();
+        stopper.stop();
     });
 
-    macos_module::run_main_loop();
+    main_loop.run();
 }
 
 pub async fn run() -> AppResult<()> {

--- a/tui-module/src/main.rs
+++ b/tui-module/src/main.rs
@@ -30,6 +30,7 @@ struct Arguments {
     command: Option<SharedCommands>,
 }
 
+#[cfg(not(target_os = "macos"))]
 #[tokio::main]
 async fn main() {
     match run().await {
@@ -38,6 +39,26 @@ async fn main() {
             eprintln!("{err}");
         }
     }
+}
+
+#[cfg(target_os = "macos")]
+fn main() {
+    std::thread::spawn(|| {
+        match tokio::runtime::Runtime::new() {
+            Ok(runtime) => {
+                if let Err(err) = runtime.block_on(run()) {
+                    eprintln!("{err}");
+                }
+            }
+            Err(err) => {
+                eprintln!("{err}");
+            }
+        }
+
+        macos_module::stop_main_loop();
+    });
+
+    macos_module::run_main_loop();
 }
 
 pub async fn run() -> AppResult<()> {
@@ -78,6 +99,9 @@ pub async fn run() -> AppResult<()> {
 
     #[cfg(target_os = "linux")]
     spawn_mpris(&player, &exit_sender, "qobine".to_string());
+
+    #[cfg(target_os = "macos")]
+    macos_module::spawn_now_playing(&player, &exit_sender);
 
     #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
     {

--- a/tui-module/src/main.rs
+++ b/tui-module/src/main.rs
@@ -43,25 +43,14 @@ async fn main() {
 
 #[cfg(target_os = "macos")]
 fn main() {
-    let main_loop = macos_module::MainLoop::new();
-    let stopper = main_loop.stopper();
-
-    std::thread::spawn(move || {
-        match tokio::runtime::Runtime::new() {
-            Ok(runtime) => {
-                if let Err(err) = runtime.block_on(run()) {
-                    eprintln!("{err}");
-                }
-            }
+    macos_module::run_with_main_loop(|| async {
+        match run().await {
+            Ok(()) => {}
             Err(err) => {
                 eprintln!("{err}");
             }
         }
-
-        stopper.stop();
     });
-
-    main_loop.run();
 }
 
 pub async fn run() -> AppResult<()> {


### PR DESCRIPTION
macOS platform is currently not supported, meaning that the desktop environment is unaware that a track is being played. 

This PR aims to bring parity with other platforms (linux and windows (and bsd?)). It communicates with Control Center, and allow for control even from connected devices such as bluetooth headphones (currently playing/pausing from headphones just opens apple music, default behavior).

Added in a separate module.

<img width="308" height="83" alt="Capture d’écran 2026-07-29 à 11 48 30" src="https://github.com/user-attachments/assets/a59b075f-b269-436a-a826-92114ab596c3" />
