### PR TITLE
TUI navigation: QoL improvements

### DIFF
--- a/tui-module/src/detail_pages.rs
+++ b/tui-module/src/detail_pages.rs
@@ -29,8 +29,8 @@ pub use track_info::TrackInfoOverlay;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum OverlayFocus {
-    #[default]
     Sidebar,
+    #[default]
     Content,
 }
 

--- a/tui-module/src/detail_pages/album.rs
+++ b/tui-module/src/detail_pages/album.rs
@@ -20,7 +20,7 @@ use crate::{
     image_cache::{AppImage, ImageManager},
     ui::{
         ALBUM_COVER_GAP, ALBUM_COVER_HEIGHT, ALBUM_COVER_WIDTH, block, format_seconds,
-        mark_as_favorite, sidebar,
+        leaves_content, mark_as_favorite, sidebar,
     },
     widgets::{
         grid::Grid,
@@ -119,12 +119,24 @@ impl AlbumOverlay {
         controls: &Controls,
         notifications: &mut NotificationList,
     ) -> AppResult<Output> {
+        if code == KeyCode::Char('G') {
+            return self.open_artist(client).await;
+        }
+
         match self.focus {
             OverlayFocus::Sidebar => self.handle_sidebar_event(code, client).await,
 
             OverlayFocus::Content => {
-                self.handle_content_event(code, client, controls, notifications)
-                    .await
+                let output = self
+                    .handle_content_event(code, client, controls, notifications)
+                    .await?;
+
+                if leaves_content(code, &output) {
+                    self.focus = OverlayFocus::Sidebar;
+                    return Ok(Output::Consumed);
+                }
+
+                Ok(output)
             }
         }
     }
@@ -303,7 +315,7 @@ impl AlbumOverlay {
 
             KeyCode::Esc => Ok(Output::PopOverlay),
 
-            _ => Ok(Output::Consumed),
+            _ => Ok(Output::NotConsumed),
         }
     }
 
@@ -314,25 +326,18 @@ impl AlbumOverlay {
         controls: &Controls,
         notifications: &mut NotificationList,
     ) -> AppResult<Output> {
-        match code {
-            KeyCode::Esc => {
-                self.focus = OverlayFocus::Sidebar;
-                return Ok(Output::Consumed);
-            }
-
-            KeyCode::Char('G') => {
-                return self.open_artist(client).await;
-            }
-
-            _ => {}
+        if code == KeyCode::Esc {
+            self.focus = OverlayFocus::Sidebar;
+            return Ok(Output::Consumed);
         }
 
         match self.selected_tab_kind() {
             Some(AlbumTabKind::About) => {
-                if let Some(delta) = about_scroll_delta(code) {
-                    scroll_about(&mut self.about_scroll, delta);
-                }
+                let Some(delta) = about_scroll_delta(code) else {
+                    return Ok(Output::NotConsumed);
+                };
 
+                scroll_about(&mut self.about_scroll, delta);
                 Ok(Output::Consumed)
             }
 
@@ -340,7 +345,7 @@ impl AlbumOverlay {
                 if code == KeyCode::Enter {
                     self.open_artist(client).await
                 } else {
-                    Ok(Output::Consumed)
+                    Ok(Output::NotConsumed)
                 }
             }
 

--- a/tui-module/src/detail_pages/artist.rs
+++ b/tui-module/src/detail_pages/artist.rs
@@ -15,7 +15,7 @@ use super::{OverlayFocus, about_scroll_delta, header_blurb, render_about, scroll
 use crate::{
     app::{FavoriteIds, NotificationList, Output},
     image_cache::{AppImage, ImageManager},
-    ui::{block, mark_as_favorite, sidebar},
+    ui::{block, leaves_content, mark_as_favorite, sidebar},
     widgets::{
         grid::Grid,
         track_list::{TrackList, TrackListEvent},
@@ -113,8 +113,16 @@ impl ArtistOverlay {
             OverlayFocus::Sidebar => Ok(self.handle_sidebar_event(code)),
 
             OverlayFocus::Content => {
-                self.handle_content_event(code, client, controls, notifications)
-                    .await
+                let output = self
+                    .handle_content_event(code, client, controls, notifications)
+                    .await?;
+
+                if leaves_content(code, &output) {
+                    self.focus = OverlayFocus::Sidebar;
+                    return Ok(Output::Consumed);
+                }
+
+                Ok(output)
             }
         }
     }
@@ -282,7 +290,7 @@ impl ArtistOverlay {
 
             KeyCode::Esc => Output::PopOverlay,
 
-            _ => Output::Consumed,
+            _ => Output::NotConsumed,
         }
     }
 
@@ -299,10 +307,11 @@ impl ArtistOverlay {
         }
 
         if self.selected_tab_kind() == Some(ArtistTabKind::About) {
-            if let Some(delta) = about_scroll_delta(code) {
-                scroll_about(&mut self.about_scroll, delta);
-            }
+            let Some(delta) = about_scroll_delta(code) else {
+                return Ok(Output::NotConsumed);
+            };
 
+            scroll_about(&mut self.about_scroll, delta);
             return Ok(Output::Consumed);
         }
 

--- a/tui-module/src/detail_pages/track_info.rs
+++ b/tui-module/src/detail_pages/track_info.rs
@@ -83,7 +83,7 @@ impl TrackInfoOverlay {
 
             KeyCode::Esc => Ok(Output::PopOverlay),
 
-            _ => Ok(Output::Consumed),
+            _ => Ok(Output::NotConsumed),
         }
     }
 

--- a/tui-module/src/discover.rs
+++ b/tui-module/src/discover.rs
@@ -12,7 +12,7 @@ use ratatui::{
 
 use crate::app::FavoriteIds;
 use crate::image_cache::ImageManager;
-use crate::ui::sidebar;
+use crate::ui::{leaves_content, sidebar};
 use crate::widgets::grid::Grid;
 use crate::{
     app::{NotificationList, Output},
@@ -164,9 +164,17 @@ impl DiscoverState {
                         self.focus = DiscoverFocus::Sidebar;
                         Ok(Output::Consumed)
                     }
-                    _ => {
-                        self.handle_content_events(key_event.code, client, controls, notifications)
-                            .await
+                    code => {
+                        let output = self
+                            .handle_content_events(code, client, controls, notifications)
+                            .await?;
+
+                        if leaves_content(code, &output) {
+                            self.focus = DiscoverFocus::Sidebar;
+                            return Ok(Output::Consumed);
+                        }
+
+                        Ok(output)
                     }
                 },
             },

--- a/tui-module/src/favorites.rs
+++ b/tui-module/src/favorites.rs
@@ -16,7 +16,7 @@ use crate::{
     app::{NotificationList, Output},
     image_cache::ImageManager,
     sub_tab::SubTab,
-    ui::{block, render_input, sidebar},
+    ui::{block, leaves_content, render_input, sidebar},
     widgets::{
         grid::Grid,
         track_list::{TrackList, TrackListEvent},
@@ -223,14 +223,22 @@ impl FavoritesState {
                                     self.focus = FavoritesFocus::Sidebar;
                                     Ok(Output::Consumed)
                                 }
-                                _ => {
-                                    self.handle_content_events(
-                                        key_event.code,
-                                        client,
-                                        controls,
-                                        notifications,
-                                    )
-                                    .await
+                                code => {
+                                    let output = self
+                                        .handle_content_events(
+                                            code,
+                                            client,
+                                            controls,
+                                            notifications,
+                                        )
+                                        .await?;
+
+                                    if leaves_content(code, &output) {
+                                        self.focus = FavoritesFocus::Sidebar;
+                                        return Ok(Output::Consumed);
+                                    }
+
+                                    Ok(output)
                                 }
                             },
                         },

--- a/tui-module/src/genres.rs
+++ b/tui-module/src/genres.rs
@@ -17,7 +17,7 @@ use ratatui::{
 use crate::{
     app::FavoriteIds,
     image_cache::ImageManager,
-    ui::{SELECTED_STYLE, sidebar},
+    ui::{SELECTED_STYLE, leaves_content, sidebar},
     widgets::grid::Grid,
 };
 use crate::{
@@ -331,7 +331,7 @@ impl GenresState {
                 self.load_genre(client).await?;
                 self.mode = GenresMode::GenreDetail;
                 self.selected_sub_tab = 0;
-                self.focus = GenresFocus::Sidebar;
+                self.focus = GenresFocus::Content;
 
                 Ok(Output::Consumed)
             }
@@ -346,43 +346,48 @@ impl GenresState {
         controls: &Controls,
         notifications: &mut NotificationList,
     ) -> AppResult<Output> {
-        match code {
-            KeyCode::Esc | KeyCode::Char('q') => {
-                self.mode = GenresMode::GenreList;
-                self.focus = GenresFocus::Sidebar;
+        match self.focus {
+            GenresFocus::Sidebar => match code {
+                KeyCode::Esc => {
+                    self.mode = GenresMode::GenreList;
 
-                Ok(Output::Consumed)
-            }
-            _ => match self.focus {
-                GenresFocus::Sidebar => match code {
-                    KeyCode::Up | KeyCode::Char('k') => {
-                        self.cycle_subtab_backwards();
+                    Ok(Output::Consumed)
+                }
+                KeyCode::Up | KeyCode::Char('k') => {
+                    self.cycle_subtab_backwards();
 
-                        Ok(Output::Consumed)
-                    }
-                    KeyCode::Down | KeyCode::Char('j') => {
-                        self.cycle_subtab();
+                    Ok(Output::Consumed)
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    self.cycle_subtab();
 
-                        Ok(Output::Consumed)
-                    }
-                    KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') => {
-                        self.focus = GenresFocus::Content;
+                    Ok(Output::Consumed)
+                }
+                KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') => {
+                    self.focus = GenresFocus::Content;
 
-                        Ok(Output::Consumed)
-                    }
-                    _ => Ok(Output::NotConsumed),
-                },
-                GenresFocus::Content => match code {
-                    KeyCode::Esc => {
+                    Ok(Output::Consumed)
+                }
+                _ => Ok(Output::NotConsumed),
+            },
+            GenresFocus::Content => match code {
+                KeyCode::Esc => {
+                    self.focus = GenresFocus::Sidebar;
+
+                    Ok(Output::Consumed)
+                }
+                code => {
+                    let output = self
+                        .handle_selected_content_events(code, client, controls, notifications)
+                        .await?;
+
+                    if leaves_content(code, &output) {
                         self.focus = GenresFocus::Sidebar;
+                        return Ok(Output::Consumed);
+                    }
 
-                        Ok(Output::Consumed)
-                    }
-                    _ => {
-                        self.handle_selected_content_events(code, client, controls, notifications)
-                            .await
-                    }
-                },
+                    Ok(output)
+                }
             },
         }
     }

--- a/tui-module/src/search.rs
+++ b/tui-module/src/search.rs
@@ -14,7 +14,7 @@ use crate::{
     app::{FavoriteIds, NotificationList, Output},
     image_cache::ImageManager,
     sub_tab::SubTab,
-    ui::{block, render_input, sidebar},
+    ui::{block, leaves_content, render_input, sidebar},
     widgets::{
         grid::Grid,
         track_list::{TrackList, TrackListEvent},
@@ -129,7 +129,7 @@ impl SearchState {
             Event::Key(key_event) if key_event.kind == KeyEventKind::Press => match self.focus {
                 SearchFocus::Editing => match key_event.code {
                     KeyCode::Esc | KeyCode::Enter => {
-                        self.focus = SearchFocus::Sidebar;
+                        self.focus = SearchFocus::Content;
                         self.update_search(client).await?;
                         Ok(Output::Consumed)
                     }
@@ -166,9 +166,17 @@ impl SearchState {
                         self.focus = SearchFocus::Sidebar;
                         Ok(Output::Consumed)
                     }
-                    _ => {
-                        self.handle_content_events(key_event.code, client, controls, notifications)
-                            .await
+                    code => {
+                        let output = self
+                            .handle_content_events(code, client, controls, notifications)
+                            .await?;
+
+                        if leaves_content(code, &output) {
+                            self.focus = SearchFocus::Sidebar;
+                            return Ok(Output::Consumed);
+                        }
+
+                        Ok(output)
                     }
                 },
             },

--- a/tui-module/src/ui.rs
+++ b/tui-module/src/ui.rs
@@ -1,6 +1,7 @@
 use num_traits::ToPrimitive;
 use player_module::notification::Notification;
 use ratatui::{
+    crossterm::event::KeyCode,
     layout::Flex,
     prelude::*,
     widgets::{
@@ -11,7 +12,7 @@ use ratatui::{
 use tui_input::Input;
 
 use crate::{
-    app::{App, AppState, Tab},
+    app::{App, AppState, Output, Tab},
     image_cache::ImageManager,
     now_playing::{self, NowPlayingState},
     widgets::focus,
@@ -302,7 +303,7 @@ fn render_help(frame: &mut Frame, area: Rect) {
         ["Stop edit filter", "escape"],
         ["Select in list", "Up/Down"],
         ["Select selected item", "Enter"],
-        ["Cycle subgroup", "Left/right"],
+        ["Switch sidebar / content", "Left/Right"],
         ["Shuffle tracks", "S"],
         ["Add to queue", "B"],
         ["Play next", "N"],
@@ -432,6 +433,10 @@ pub fn sidebar(tabs: Vec<&str>, focused: bool) -> (List<'_>, u16) {
         .highlight_style(highlight_style);
 
     (list, width)
+}
+
+pub const fn leaves_content(code: KeyCode, output: &Output) -> bool {
+    matches!(output, Output::NotConsumed) && matches!(code, KeyCode::Left | KeyCode::Char('h'))
 }
 
 pub fn mark_explicit_and_hifi(

--- a/tui-module/src/widgets/grid.rs
+++ b/tui-module/src/widgets/grid.rs
@@ -216,6 +216,10 @@ where
             }
 
             KeyCode::Left | KeyCode::Char('h') => {
+                if self.at_row_start() {
+                    return Ok(Output::NotConsumed);
+                }
+
                 self.move_selection(-1);
                 Ok(Output::Consumed)
             }
@@ -277,6 +281,13 @@ where
     pub fn set_all_items(&mut self, items: Vec<T>) {
         self.items.set_all_items(items);
         self.reset_view();
+    }
+
+    fn at_row_start(&self) -> bool {
+        self.items
+            .state
+            .selected()
+            .is_none_or(|selected| selected.checked_rem(self.columns).unwrap_or_default() == 0)
     }
 
     fn move_selection(&mut self, delta: isize) {


### PR DESCRIPTION
* Album and artist pages open with the content focused, so only need 2 enter press to start playing an album tracks (was 3 before) (one to open the album view, one to start the first track)
* left arrow leaves the content everywhere, so we can go back to the sidebar with it instead of having to reach for escape. NB: grid left no longer wraps to the previous row last card
* genres detail page had an unreachable escape (an outer match caught the esc before the inner one, so the one from content jumped straight back to the genre list instead of the sidebar. It also mapped q to "back", which shadowed the global quit - I'm not sure why, you can revert that if it was intentional)
* album, artist and track-info sidebars broke every unbound key (pausing with space wasn't possible when in the sidebar focus for ex)
* search results land in the content after submitting a query instead of the sidebar (so can navigate the results immediately)
* Help text change