### PR TITLE
TUI: refactor the focus enum into a shared Pane

### DIFF
--- a/tui-module/src/app.rs
+++ b/tui-module/src/app.rs
@@ -644,7 +644,7 @@ impl App {
     }
 
     const fn navigate_to_search(&mut self) {
-        self.search.focus_editing();
+        self.search.start_editing();
         self.current_screen = Tab::Search;
     }
 

--- a/tui-module/src/detail_pages.rs
+++ b/tui-module/src/detail_pages.rs
@@ -27,13 +27,6 @@ pub use new_playlist::NewPlaylistOverlay;
 pub use playlist::PlaylistOverlay;
 pub use track_info::TrackInfoOverlay;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum OverlayFocus {
-    Sidebar,
-    #[default]
-    Content,
-}
-
 #[allow(clippy::large_enum_variant)]
 pub enum Overlay {
     Artist(ArtistOverlay),

--- a/tui-module/src/detail_pages/album.rs
+++ b/tui-module/src/detail_pages/album.rs
@@ -11,15 +11,12 @@ use ratatui::{
 };
 use ratatui_image::StatefulImage;
 
-use super::{
-    ArtistOverlay, Overlay, OverlayFocus, about_scroll_delta, header_blurb, render_about,
-    scroll_about,
-};
+use super::{ArtistOverlay, Overlay, about_scroll_delta, header_blurb, render_about, scroll_about};
 use crate::{
     app::{FavoriteIds, NotificationList, Output},
     image_cache::{AppImage, ImageManager},
     ui::{
-        ALBUM_COVER_GAP, ALBUM_COVER_HEIGHT, ALBUM_COVER_WIDTH, block, format_seconds,
+        ALBUM_COVER_GAP, ALBUM_COVER_HEIGHT, ALBUM_COVER_WIDTH, Pane, block, format_seconds,
         leaves_content, mark_as_favorite, sidebar,
     },
     widgets::{
@@ -29,7 +26,7 @@ use crate::{
 };
 
 pub struct AlbumOverlay {
-    focus: OverlayFocus,
+    focus: Pane,
     title: String,
     artist: Artist,
     tracks: TrackList,
@@ -67,7 +64,7 @@ impl AlbumOverlay {
         let similar = client.suggested_albums(&album.id).await.unwrap_or_default();
 
         Self {
-            focus: OverlayFocus::default(),
+            focus: Pane::Content,
             title: album.title,
             artist: album.artist,
             tracks: TrackList::new(album.tracks),
@@ -124,15 +121,15 @@ impl AlbumOverlay {
         }
 
         match self.focus {
-            OverlayFocus::Sidebar => self.handle_sidebar_event(code, client).await,
+            Pane::Sidebar => self.handle_sidebar_event(code, client).await,
 
-            OverlayFocus::Content => {
+            Pane::Content => {
                 let output = self
                     .handle_content_event(code, client, controls, notifications)
                     .await?;
 
                 if leaves_content(code, &output) {
-                    self.focus = OverlayFocus::Sidebar;
+                    self.focus = Pane::Sidebar;
                     return Ok(Output::Consumed);
                 }
 
@@ -230,8 +227,7 @@ impl AlbumOverlay {
         favorites: &FavoriteIds,
         image_cache: &mut ImageManager,
     ) {
-        let (sidebar_widget, sidebar_width) =
-            sidebar(self.tabs(), self.focus == OverlayFocus::Sidebar);
+        let (sidebar_widget, sidebar_width) = sidebar(self.tabs(), self.focus == Pane::Sidebar);
 
         let [sidebar_area, content_area] =
             Layout::horizontal([Constraint::Length(sidebar_width), Constraint::Min(1)]).areas(area);
@@ -309,7 +305,7 @@ impl AlbumOverlay {
                     return self.open_artist(client).await;
                 }
 
-                self.focus = OverlayFocus::Content;
+                self.focus = Pane::Content;
                 Ok(Output::Consumed)
             }
 
@@ -327,7 +323,7 @@ impl AlbumOverlay {
         notifications: &mut NotificationList,
     ) -> AppResult<Output> {
         if code == KeyCode::Esc {
-            self.focus = OverlayFocus::Sidebar;
+            self.focus = Pane::Sidebar;
             return Ok(Output::Consumed);
         }
 

--- a/tui-module/src/detail_pages/artist.rs
+++ b/tui-module/src/detail_pages/artist.rs
@@ -11,11 +11,11 @@ use ratatui::{
 };
 use ratatui_image::StatefulImage;
 
-use super::{OverlayFocus, about_scroll_delta, header_blurb, render_about, scroll_about};
+use super::{about_scroll_delta, header_blurb, render_about, scroll_about};
 use crate::{
     app::{FavoriteIds, NotificationList, Output},
     image_cache::{AppImage, ImageManager},
-    ui::{block, leaves_content, mark_as_favorite, sidebar},
+    ui::{Pane, block, leaves_content, mark_as_favorite, sidebar},
     widgets::{
         grid::Grid,
         track_list::{TrackList, TrackListEvent},
@@ -23,7 +23,7 @@ use crate::{
 };
 
 pub struct ArtistOverlay {
-    focus: OverlayFocus,
+    focus: Pane,
     artist_name: String,
     albums: Grid<AlbumSimple>,
     singles: Grid<AlbumSimple>,
@@ -60,7 +60,7 @@ impl ArtistOverlay {
         let artist_page = client.artist_page(artist.id).await?;
 
         Ok(Self {
-            focus: OverlayFocus::default(),
+            focus: Pane::Content,
             artist_name: artist.name.clone(),
             albums: Grid::new(artist_page.albums),
             singles: Grid::new(artist_page.singles),
@@ -110,15 +110,15 @@ impl ArtistOverlay {
         notifications: &mut NotificationList,
     ) -> AppResult<Output> {
         match self.focus {
-            OverlayFocus::Sidebar => Ok(self.handle_sidebar_event(code)),
+            Pane::Sidebar => Ok(self.handle_sidebar_event(code)),
 
-            OverlayFocus::Content => {
+            Pane::Content => {
                 let output = self
                     .handle_content_event(code, client, controls, notifications)
                     .await?;
 
                 if leaves_content(code, &output) {
-                    self.focus = OverlayFocus::Sidebar;
+                    self.focus = Pane::Sidebar;
                     return Ok(Output::Consumed);
                 }
 
@@ -200,8 +200,7 @@ impl ArtistOverlay {
         favorites: &FavoriteIds,
         image_cache: &mut ImageManager,
     ) {
-        let (sidebar_widget, sidebar_width) =
-            sidebar(self.tabs(), self.focus == OverlayFocus::Sidebar);
+        let (sidebar_widget, sidebar_width) = sidebar(self.tabs(), self.focus == Pane::Sidebar);
 
         let [sidebar_area, content_area] =
             Layout::horizontal([Constraint::Length(sidebar_width), Constraint::Min(1)]).areas(area);
@@ -284,7 +283,7 @@ impl ArtistOverlay {
             }
 
             KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') => {
-                self.focus = OverlayFocus::Content;
+                self.focus = Pane::Content;
                 Output::Consumed
             }
 
@@ -302,7 +301,7 @@ impl ArtistOverlay {
         notifications: &mut NotificationList,
     ) -> AppResult<Output> {
         if matches!(code, KeyCode::Esc) {
-            self.focus = OverlayFocus::Sidebar;
+            self.focus = Pane::Sidebar;
             return Ok(Output::Consumed);
         }
 

--- a/tui-module/src/discover.rs
+++ b/tui-module/src/discover.rs
@@ -12,25 +12,18 @@ use ratatui::{
 
 use crate::app::FavoriteIds;
 use crate::image_cache::ImageManager;
-use crate::ui::{leaves_content, sidebar};
+use crate::ui::{Pane, leaves_content, sidebar};
 use crate::widgets::grid::Grid;
 use crate::{
     app::{NotificationList, Output},
     ui::block,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-enum DiscoverFocus {
-    #[default]
-    Sidebar,
-    Content,
-}
-
 pub struct DiscoverState {
     featured_albums: Vec<(String, Grid<AlbumSimple>)>,
     featured_playlists: Vec<(String, Grid<PlaylistSimple>)>,
     selected_sub_tab: usize,
-    focus: DiscoverFocus,
+    focus: Pane,
 }
 
 impl DiscoverState {
@@ -75,7 +68,7 @@ impl DiscoverState {
             featured_albums,
             featured_playlists,
             selected_sub_tab: 0,
-            focus: DiscoverFocus::default(),
+            focus: Pane::default(),
         })
     }
 
@@ -102,7 +95,7 @@ impl DiscoverState {
             )
             .collect::<Vec<_>>();
 
-        let (sidebar, sidebar_width) = sidebar(labels, self.focus == DiscoverFocus::Sidebar);
+        let (sidebar, sidebar_width) = sidebar(labels, self.focus == Pane::Sidebar);
 
         let [sidebar_area, content_area] = Layout::default()
             .direction(Direction::Horizontal)
@@ -114,7 +107,7 @@ impl DiscoverState {
 
         frame.render_stateful_widget(sidebar, sidebar_area, &mut sidebar_state);
 
-        let content_focused = self.focus == DiscoverFocus::Content;
+        let content_focused = self.focus == Pane::Content;
 
         if let Some((_, list)) = self.selected_album_mut() {
             list.render(
@@ -144,7 +137,7 @@ impl DiscoverState {
     ) -> AppResult<Output> {
         match event {
             Event::Key(key_event) if key_event.kind == KeyEventKind::Press => match self.focus {
-                DiscoverFocus::Sidebar => match key_event.code {
+                Pane::Sidebar => match key_event.code {
                     KeyCode::Up | KeyCode::Char('k') => {
                         self.cycle_subtab_backwards();
                         Ok(Output::Consumed)
@@ -154,14 +147,14 @@ impl DiscoverState {
                         Ok(Output::Consumed)
                     }
                     KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') => {
-                        self.focus = DiscoverFocus::Content;
+                        self.focus = Pane::Content;
                         Ok(Output::Consumed)
                     }
                     _ => Ok(Output::NotConsumed),
                 },
-                DiscoverFocus::Content => match key_event.code {
+                Pane::Content => match key_event.code {
                     KeyCode::Esc => {
-                        self.focus = DiscoverFocus::Sidebar;
+                        self.focus = Pane::Sidebar;
                         Ok(Output::Consumed)
                     }
                     code => {
@@ -170,7 +163,7 @@ impl DiscoverState {
                             .await?;
 
                         if leaves_content(code, &output) {
-                            self.focus = DiscoverFocus::Sidebar;
+                            self.focus = Pane::Sidebar;
                             return Ok(Output::Consumed);
                         }
 

--- a/tui-module/src/favorites.rs
+++ b/tui-module/src/favorites.rs
@@ -16,19 +16,12 @@ use crate::{
     app::{NotificationList, Output},
     image_cache::ImageManager,
     sub_tab::SubTab,
-    ui::{block, leaves_content, render_input, sidebar},
+    ui::{Pane, block, leaves_content, render_input, sidebar},
     widgets::{
         grid::Grid,
         track_list::{TrackList, TrackListEvent},
     },
 };
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-enum FavoritesFocus {
-    #[default]
-    Sidebar,
-    Content,
-}
 
 pub struct FavoritesState {
     filter: Input,
@@ -38,7 +31,7 @@ pub struct FavoritesState {
     pub tracks: TrackList,
     editing: bool,
     sub_tab: SubTab,
-    focus: FavoritesFocus,
+    focus: Pane,
 }
 
 impl FavoritesState {
@@ -59,7 +52,7 @@ impl FavoritesState {
             ),
             tracks: TrackList::new(favorites.tracks),
             sub_tab: SubTab::default(),
-            focus: FavoritesFocus::default(),
+            focus: Pane::default(),
         })
     }
 
@@ -73,10 +66,8 @@ impl FavoritesState {
         let block = block(None);
         frame.render_widget(block, content_area);
 
-        let (sidebar, sidebar_width) = sidebar(
-            SubTab::labels().to_vec(),
-            self.focus == FavoritesFocus::Sidebar,
-        );
+        let (sidebar, sidebar_width) =
+            sidebar(SubTab::labels().to_vec(), self.focus == Pane::Sidebar);
 
         let content_area = content_area.inner(Margin::new(1, 1));
         let [sidebar_area, content_area] = Layout::default()
@@ -89,7 +80,7 @@ impl FavoritesState {
 
         frame.render_stateful_widget(sidebar, sidebar_area, &mut sidebar_state);
 
-        let content_focused = self.focus == FavoritesFocus::Content;
+        let content_focused = self.focus == Pane::Content;
         match self.sub_tab {
             SubTab::Albums => self.albums.render(
                 content_area,
@@ -203,7 +194,7 @@ impl FavoritesState {
                             Ok(Output::Consumed)
                         }
                         _ => match self.focus {
-                            FavoritesFocus::Sidebar => match key_event.code {
+                            Pane::Sidebar => match key_event.code {
                                 KeyCode::Up | KeyCode::Char('k') => {
                                     self.cycle_subtab_backwards();
                                     Ok(Output::Consumed)
@@ -213,14 +204,14 @@ impl FavoritesState {
                                     Ok(Output::Consumed)
                                 }
                                 KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') => {
-                                    self.focus = FavoritesFocus::Content;
+                                    self.focus = Pane::Content;
                                     Ok(Output::Consumed)
                                 }
                                 _ => Ok(Output::NotConsumed),
                             },
-                            FavoritesFocus::Content => match key_event.code {
+                            Pane::Content => match key_event.code {
                                 KeyCode::Esc => {
-                                    self.focus = FavoritesFocus::Sidebar;
+                                    self.focus = Pane::Sidebar;
                                     Ok(Output::Consumed)
                                 }
                                 code => {
@@ -234,7 +225,7 @@ impl FavoritesState {
                                         .await?;
 
                                     if leaves_content(code, &output) {
-                                        self.focus = FavoritesFocus::Sidebar;
+                                        self.focus = Pane::Sidebar;
                                         return Ok(Output::Consumed);
                                     }
 

--- a/tui-module/src/genres.rs
+++ b/tui-module/src/genres.rs
@@ -17,7 +17,7 @@ use ratatui::{
 use crate::{
     app::FavoriteIds,
     image_cache::ImageManager,
-    ui::{SELECTED_STYLE, leaves_content, sidebar},
+    ui::{Pane, SELECTED_STYLE, leaves_content, sidebar},
     widgets::grid::Grid,
 };
 use crate::{
@@ -30,7 +30,7 @@ pub struct GenresState {
     selected_genre: usize,
     selected_sub_tab: usize,
     mode: GenresMode,
-    focus: GenresFocus,
+    focus: Pane,
 }
 
 struct GenreItem {
@@ -44,13 +44,6 @@ struct GenreItem {
 enum GenresMode {
     GenreList,
     GenreDetail,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-enum GenresFocus {
-    #[default]
-    Sidebar,
-    Content,
 }
 
 impl GenresState {
@@ -72,7 +65,7 @@ impl GenresState {
             selected_genre: 0,
             selected_sub_tab: 0,
             mode: GenresMode::GenreList,
-            focus: GenresFocus::default(),
+            focus: Pane::default(),
         })
     }
 
@@ -240,7 +233,7 @@ impl GenresState {
             .chain(genre.playlists.iter().map(|(label, _)| label.as_str()))
             .collect::<Vec<_>>();
 
-        let (sidebar, sidebar_width) = sidebar(labels, self.focus == GenresFocus::Sidebar);
+        let (sidebar, sidebar_width) = sidebar(labels, self.focus == Pane::Sidebar);
 
         let [sidebar_area, content_area] =
             Layout::horizontal([Constraint::Length(sidebar_width), Constraint::Min(1)])
@@ -251,7 +244,7 @@ impl GenresState {
 
         frame.render_stateful_widget(sidebar, sidebar_area, &mut sidebar_state);
 
-        let content_focused = self.focus == GenresFocus::Content;
+        let content_focused = self.focus == Pane::Content;
 
         match self.selected_mut() {
             Some(Selected::Album(list)) => list.render(
@@ -331,7 +324,7 @@ impl GenresState {
                 self.load_genre(client).await?;
                 self.mode = GenresMode::GenreDetail;
                 self.selected_sub_tab = 0;
-                self.focus = GenresFocus::Content;
+                self.focus = Pane::Content;
 
                 Ok(Output::Consumed)
             }
@@ -347,7 +340,7 @@ impl GenresState {
         notifications: &mut NotificationList,
     ) -> AppResult<Output> {
         match self.focus {
-            GenresFocus::Sidebar => match code {
+            Pane::Sidebar => match code {
                 KeyCode::Esc => {
                     self.mode = GenresMode::GenreList;
 
@@ -364,15 +357,15 @@ impl GenresState {
                     Ok(Output::Consumed)
                 }
                 KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') => {
-                    self.focus = GenresFocus::Content;
+                    self.focus = Pane::Content;
 
                     Ok(Output::Consumed)
                 }
                 _ => Ok(Output::NotConsumed),
             },
-            GenresFocus::Content => match code {
+            Pane::Content => match code {
                 KeyCode::Esc => {
-                    self.focus = GenresFocus::Sidebar;
+                    self.focus = Pane::Sidebar;
 
                     Ok(Output::Consumed)
                 }
@@ -382,7 +375,7 @@ impl GenresState {
                         .await?;
 
                     if leaves_content(code, &output) {
-                        self.focus = GenresFocus::Sidebar;
+                        self.focus = Pane::Sidebar;
                         return Ok(Output::Consumed);
                     }
 

--- a/tui-module/src/search.rs
+++ b/tui-module/src/search.rs
@@ -14,20 +14,12 @@ use crate::{
     app::{FavoriteIds, NotificationList, Output},
     image_cache::ImageManager,
     sub_tab::SubTab,
-    ui::{block, leaves_content, render_input, sidebar},
+    ui::{Pane, block, leaves_content, render_input, sidebar},
     widgets::{
         grid::Grid,
         track_list::{TrackList, TrackListEvent},
     },
 };
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum SearchFocus {
-    #[default]
-    Sidebar,
-    Content,
-    Editing,
-}
 
 #[derive(Default)]
 pub struct SearchState {
@@ -36,8 +28,9 @@ pub struct SearchState {
     artists: Grid<Artist>,
     playlists: Grid<PlaylistSimple>,
     tracks: TrackList,
+    editing: bool,
     sub_tab: SubTab,
-    focus: SearchFocus,
+    focus: Pane,
 }
 
 impl SearchState {
@@ -52,23 +45,15 @@ impl SearchState {
             .constraints([Constraint::Length(3), Constraint::Min(1)])
             .areas(area);
 
-        render_input(
-            &self.filter,
-            self.focus == SearchFocus::Editing,
-            input_area,
-            frame,
-            "Search",
-        );
+        render_input(&self.filter, self.editing, input_area, frame, "Search");
 
         let block = block(None);
         frame.render_widget(block, content_area);
 
         let tab_content_area = content_area.inner(Margin::new(1, 1));
 
-        let (sidebar, sidebar_width) = sidebar(
-            SubTab::labels().to_vec(),
-            self.focus == SearchFocus::Sidebar,
-        );
+        let (sidebar, sidebar_width) =
+            sidebar(SubTab::labels().to_vec(), self.focus == Pane::Sidebar);
 
         let [sidebar_area, content_area] = Layout::default()
             .direction(Direction::Horizontal)
@@ -80,7 +65,7 @@ impl SearchState {
 
         frame.render_stateful_widget(sidebar, sidebar_area, &mut sidebar_state);
 
-        let content_focused = self.focus == SearchFocus::Content;
+        let content_focused = self.focus == Pane::Content;
 
         match self.sub_tab {
             SubTab::Albums => self.albums.render(
@@ -114,8 +99,8 @@ impl SearchState {
         }
     }
 
-    pub const fn focus_editing(&mut self) {
-        self.focus = SearchFocus::Editing;
+    pub const fn start_editing(&mut self) {
+        self.editing = true;
     }
 
     pub async fn handle_events(
@@ -126,60 +111,64 @@ impl SearchState {
         notifications: &mut NotificationList,
     ) -> AppResult<Output> {
         match event {
-            Event::Key(key_event) if key_event.kind == KeyEventKind::Press => match self.focus {
-                SearchFocus::Editing => match key_event.code {
-                    KeyCode::Esc | KeyCode::Enter => {
-                        self.focus = SearchFocus::Content;
-                        self.update_search(client).await?;
-                        Ok(Output::Consumed)
-                    }
-                    _ => {
-                        self.filter.handle_event(&event);
-                        Ok(Output::Consumed)
-                    }
-                },
-                SearchFocus::Sidebar => match key_event.code {
-                    KeyCode::Char('e') => {
-                        self.focus_editing();
-                        Ok(Output::Consumed)
-                    }
-                    KeyCode::Up | KeyCode::Char('k') => {
-                        self.cycle_subtab_backwards();
-                        Ok(Output::Consumed)
-                    }
-                    KeyCode::Down | KeyCode::Char('j') => {
-                        self.cycle_subtab();
-                        Ok(Output::Consumed)
-                    }
-                    KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') => {
-                        self.focus = SearchFocus::Content;
-                        Ok(Output::Consumed)
-                    }
-                    _ => Ok(Output::NotConsumed),
-                },
-                SearchFocus::Content => match key_event.code {
-                    KeyCode::Char('e') => {
-                        self.focus_editing();
-                        Ok(Output::Consumed)
-                    }
-                    KeyCode::Esc => {
-                        self.focus = SearchFocus::Sidebar;
-                        Ok(Output::Consumed)
-                    }
-                    code => {
-                        let output = self
-                            .handle_content_events(code, client, controls, notifications)
-                            .await?;
-
-                        if leaves_content(code, &output) {
-                            self.focus = SearchFocus::Sidebar;
-                            return Ok(Output::Consumed);
+            Event::Key(key_event) if key_event.kind == KeyEventKind::Press => {
+                if self.editing {
+                    return match key_event.code {
+                        KeyCode::Esc | KeyCode::Enter => {
+                            self.editing = false;
+                            self.focus = Pane::Content;
+                            self.update_search(client).await?;
+                            Ok(Output::Consumed)
                         }
+                        _ => {
+                            self.filter.handle_event(&event);
+                            Ok(Output::Consumed)
+                        }
+                    };
+                }
 
-                        Ok(output)
+                match key_event.code {
+                    KeyCode::Char('e') => {
+                        self.start_editing();
+                        Ok(Output::Consumed)
                     }
-                },
-            },
+                    _ => match self.focus {
+                        Pane::Sidebar => match key_event.code {
+                            KeyCode::Up | KeyCode::Char('k') => {
+                                self.cycle_subtab_backwards();
+                                Ok(Output::Consumed)
+                            }
+                            KeyCode::Down | KeyCode::Char('j') => {
+                                self.cycle_subtab();
+                                Ok(Output::Consumed)
+                            }
+                            KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') => {
+                                self.focus = Pane::Content;
+                                Ok(Output::Consumed)
+                            }
+                            _ => Ok(Output::NotConsumed),
+                        },
+                        Pane::Content => match key_event.code {
+                            KeyCode::Esc => {
+                                self.focus = Pane::Sidebar;
+                                Ok(Output::Consumed)
+                            }
+                            code => {
+                                let output = self
+                                    .handle_content_events(code, client, controls, notifications)
+                                    .await?;
+
+                                if leaves_content(code, &output) {
+                                    self.focus = Pane::Sidebar;
+                                    return Ok(Output::Consumed);
+                                }
+
+                                Ok(output)
+                            }
+                        },
+                    },
+                }
+            }
             _ => Ok(Output::NotConsumed),
         }
     }

--- a/tui-module/src/ui.rs
+++ b/tui-module/src/ui.rs
@@ -401,6 +401,13 @@ pub fn tab_bar(tabs: Vec<&str>, selected: usize) -> Tabs<'_> {
         .select(selected)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Pane {
+    #[default]
+    Sidebar,
+    Content,
+}
+
 pub fn sidebar(tabs: Vec<&str>, focused: bool) -> (List<'_>, u16) {
     let width = tabs
         .iter()


### PR DESCRIPTION
A small commit to clean things up:
- moved the Pane { Sidebar, Content } to ui.rs only (shared with fav, discover, albums, ...)
- album and artist pages now set Pane::Content explicitly
- aligned the Search to match Favorites